### PR TITLE
解决首句最后TTS

### DIFF
--- a/internal/domain/llm/llm.go
+++ b/internal/domain/llm/llm.go
@@ -107,7 +107,7 @@ func HandleLLMWithContextAndTools(ctx context.Context, llmProvider LLMProvider, 
 					fullText += message.Content
 					buffer.WriteString(message.Content)
 					if containsSentenceSeparator(message.Content, isFirst) {
-						sentences, remaining := extractSmartSentences(buffer.String(), 5, 100, isFirst)
+						sentences, remaining := extractSmartSentences(buffer.String(), 2, 100, isFirst)
 						if len(sentences) > 0 {
 							for _, sentence := range sentences {
 								if sentence != "" {


### PR DESCRIPTION
解决当首句分割字符数量小于设置值时，首句文本说在最后TTS的问题