### PR TITLE
适配emqx配置

### DIFF
--- a/internal/app/server/mqtt_udp/mqtt_udp_adapter.go
+++ b/internal/app/server/mqtt_udp/mqtt_udp_adapter.go
@@ -13,6 +13,7 @@ import (
 	"xiaozhi-esp32-server-golang/internal/data/client"
 	. "xiaozhi-esp32-server-golang/internal/data/client"
 	. "xiaozhi-esp32-server-golang/logger"
+	log "xiaozhi-esp32-server-golang/logger"
 )
 
 type MqttConfig struct {
@@ -234,7 +235,20 @@ func (s *MqttUdpAdapter) getDeviceIdByTopic(topic string) (string, string) {
 	strList := strings.Split(topic, "/")
 	if len(strList) == 4 {
 		topicMacAddr = strList[3]
-		deviceId = strings.ReplaceAll(topicMacAddr, "_", ":")
+
+		// 检查是否为新格式: "GID_test@@@ba_8f_17_de_94_94@@@e4b0c442-98fc-4e1b-8c3d-6a5b6a5b6a6d"
+		if strings.Contains(topicMacAddr, "@@@") {
+			parts := strings.Split(topicMacAddr, "@@@")
+			if len(parts) >= 2 {
+				// 提取中间部分作为MAC地址
+				macAddr := parts[1]
+				deviceId = strings.ReplaceAll(macAddr, "_", ":")
+			}
+		} else {
+			deviceId = strings.ReplaceAll(topicMacAddr, "_", ":")
+		}
 	}
+
+	log.Log().Debugf("topicMacAddr: %s, deviceId: %s", topicMacAddr, deviceId)
 	return topicMacAddr, deviceId
 }

--- a/internal/app/server/mqtt_udp/mqtt_udp_conn.go
+++ b/internal/app/server/mqtt_udp/mqtt_udp_conn.go
@@ -44,6 +44,7 @@ type MqttUdpConn struct {
 // NewMqttUdpConn 创建一个新的 MqttUdpConn 实例
 func NewMqttUdpConn(deviceID string, pubTopic string, mqttClient mqtt.Client, udpServer *UdpServer, udpSession *UdpSession) *MqttUdpConn {
 	ctx, cancel := context.WithCancel(context.Background())
+	log.Log().Debugf("NewMqttUdpConn pubTopic: %s", pubTopic)
 	return &MqttUdpConn{
 		ctx:      ctx,
 		cancel:   cancel,


### PR DESCRIPTION
适配emqx server

1. 自动订阅主题“/p2p/device_sub/${clientid}”
2. 在emqx server的规则中，将"device_server"的topic重定向至“/p2p/device_public/${clientid}”

