### PR TITLE
豆包 ws 链接关闭 , 释放资源,

### DIFF
--- a/internal/domain/asr/doubao/client/client_stream.go
+++ b/internal/domain/asr/doubao/client/client_stream.go
@@ -94,8 +94,6 @@ func (c *AsrWsClient) SendMessages(ctx context.Context, audioStream <-chan []flo
 			c.seq++
 		}
 	}
-
-	return nil
 }
 
 func (c *AsrWsClient) recvMessages(ctx context.Context, resChan chan<- *response.AsrResponse, stopChan chan<- struct{}) {
@@ -127,6 +125,15 @@ func (c *AsrWsClient) StartAudioStream(ctx context.Context, audioStream <-chan [
 		}
 	}()
 	c.recvMessages(ctx, resChan, stopChan)
+	return nil
+}
+
+func (c *AsrWsClient) Close() error {
+	if c.connect != nil {
+		err := c.connect.Close()
+		c.connect = nil
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
修复了豆包asr 长连接 不释放的 , 资源回收导致了 持续聊天资源耗尽 最终导致缓冲区满的问题.
这里还有一个步骤就是如果用户无法获取到asr 资源, 应该禁止 音频上传, 关闭本次回话连接, 这个步骤我没实现.