### PR TITLE
修复: 设备下线时 及时清理设备维度mcp工具

### DIFF
--- a/internal/domain/mcp/device_manager.go
+++ b/internal/domain/mcp/device_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,6 +55,33 @@ func (dcs *DeviceMcpSession) RemoveWsEndPointMcp(mcpClient *McpClientInstance) {
 	dcs.wsEndPointMcp.Delete(mcpClient.serverName)
 }
 
+func (dcs *DeviceMcpSession) removeIotOverMcp(instance *McpClientInstance) {
+	dcs.iotMux.Lock()
+	defer dcs.iotMux.Unlock()
+	if dcs.iotOverMcp != nil && dcs.iotOverMcp == instance {
+		dcs.iotOverMcp = nil
+	}
+}
+
+func (dcs *DeviceMcpSession) hasActiveMcpConnections() bool {
+	hasActiveWs := false
+	dcs.wsEndPointMcp.Range(func(_, value interface{}) bool {
+		mcpInstance := value.(*McpClientInstance)
+		if mcpInstance != nil && mcpInstance.IsConnected() {
+			hasActiveWs = true
+			return false
+		}
+		return true
+	})
+	if hasActiveWs {
+		return true
+	}
+
+	dcs.iotMux.RLock()
+	defer dcs.iotMux.RUnlock()
+	return dcs.iotOverMcp != nil && dcs.iotOverMcp.IsConnected()
+}
+
 // GetDeviceID 获取设备ID
 func (dcs *DeviceMcpSession) GetDeviceID() string {
 	return dcs.deviceID
@@ -63,14 +91,24 @@ func (dcs *DeviceMcpSession) GetDeviceID() string {
 func (dcs *DeviceMcpSession) handleMcpClientClose(instance *McpClientInstance, reason string) {
 	logger.Infof("设备 %s 的MCP客户端 %s 已关闭，原因: %s", dcs.deviceID, instance.serverName, reason)
 
-	// 从会话中移除已关闭的客户端
-	dcs.RemoveWsEndPointMcp(instance)
+	// 从会话中移除已关闭的客户端（按类型分流）
+	if strings.HasPrefix(instance.serverName, "ws_endpoint_mcp_") {
+		dcs.RemoveWsEndPointMcp(instance)
+	} else if strings.HasPrefix(instance.serverName, "iot_over_mcp_") {
+		dcs.removeIotOverMcp(instance)
+	} else {
+		// 兜底：先尝试移除ws映射，再尝试清理iot引用
+		dcs.RemoveWsEndPointMcp(instance)
+		dcs.removeIotOverMcp(instance)
+	}
 
-	// 如果所有WebSocket端点都关闭了，可以考虑清理整个会话
-	/*if len(dcs.wsEndPointMcp) == 0 && dcs.iotOverMcp == nil {
-		logger.Infof("设备 %s 的所有MCP连接已关闭，清理会话", dcs.deviceID)
+	if !dcs.hasActiveMcpConnections() {
+		logger.Infof("设备 %s 的所有MCP连接已关闭，清理设备级MCP会话", dcs.deviceID)
 		dcs.cancel()
-	}*/
+		if err := RemoveDeviceMcpClient(dcs.deviceID); err != nil {
+			logger.Errorf("清理设备 %s 的MCP会话失败: %v", dcs.deviceID, err)
+		}
+	}
 }
 
 // McpClientInstance 代表一个具体的MCP客户端连接

--- a/internal/domain/mcp/mcp_pool.go
+++ b/internal/domain/mcp/mcp_pool.go
@@ -77,34 +77,44 @@ func (p *McpClientPool) GetWsEndpointMcpTools(agentId string) (map[string]tool.I
 }
 
 func (p *McpClientPool) checkOffline() {
-	for _, client := range p.device2McpClient.Items() {
-		// 检查WebSocket端点MCP连接
-		hasActiveWsConnections := false
-		client.wsEndPointMcp.Range(func(_, value interface{}) bool {
-			wsInstance := value.(*McpClientInstance)
-			if time.Since(wsInstance.lastPing) > 2*time.Minute {
-				wsInstance.connected = false
-				wsInstance.cancel()
-			} else {
-				hasActiveWsConnections = true
-			}
-			return true //continue
-		})
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
 
-		// 检查IoT over MCP连接
-		hasActiveIotConnection := false
-		if client.iotOverMcp != nil {
-			if time.Since(client.iotOverMcp.lastPing) > 2*time.Minute {
-				client.iotOverMcp.connected = false
-				client.iotOverMcp.cancel()
-			} else {
-				hasActiveIotConnection = true
-			}
-		}
+	for range ticker.C {
+		for _, deviceSession := range p.device2McpClient.Items() {
+			// 检查WebSocket端点MCP连接
+			hasActiveWsConnections := false
+			deviceSession.wsEndPointMcp.Range(func(_, value interface{}) bool {
+				wsInstance := value.(*McpClientInstance)
+				if time.Since(wsInstance.lastPing) > 2*time.Minute {
+					wsInstance.connected = false
+					wsInstance.cancel()
+					deviceSession.RemoveWsEndPointMcp(wsInstance)
+				} else {
+					hasActiveWsConnections = true
+				}
+				return true // continue
+			})
 
-		// 如果没有任何活跃连接，移除客户端
-		if !hasActiveWsConnections && !hasActiveIotConnection {
-			p.RemoveMcpClient(client.deviceID)
+			// 检查IoT over MCP连接
+			hasActiveIotConnection := false
+			deviceSession.iotMux.Lock()
+			if deviceSession.iotOverMcp != nil {
+				if time.Since(deviceSession.iotOverMcp.lastPing) > 2*time.Minute {
+					deviceSession.iotOverMcp.connected = false
+					deviceSession.iotOverMcp.cancel()
+					deviceSession.iotOverMcp = nil
+				} else {
+					hasActiveIotConnection = true
+				}
+			}
+			deviceSession.iotMux.Unlock()
+
+			// 如果没有任何活跃连接，移除设备维度MCP会话
+			if !hasActiveWsConnections && !hasActiveIotConnection {
+				deviceSession.cancel()
+				p.RemoveMcpClient(deviceSession.deviceID)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Motivation
- 解决设备级 MCP 会话在不同传输模式下未被正确清理的问题，保证 websocket 模式断连即时清理工具而 mqtt/udp 模式依赖心跳超时清理。

### Description
- 在 `internal/domain/mcp/device_manager.go` 中新增 `removeIotOverMcp` 与 `hasActiveMcpConnections`，并在 `handleMcpClientClose` 中按 `serverName` 前缀区分 `ws_endpoint_mcp_` 与 `iot_over_mcp_` 进行精确移除与会话取消逻辑。 
- 在 `internal/domain/mcp/mcp_pool.go` 中将 `checkOffline` 从一次性遍历改为每 30 秒的 `ticker` 周期巡检，检查并取消超过 2 分钟未心跳的 `ws` 与 `iot` 实例，并在无活跃连接时移除设备级会话。 
- 调整移除流程以确保在超时/断开时调用 `RemoveWsEndPointMcp` 或将 `iotOverMcp` 在锁内清空，从而避免遗留工具引用。

### Testing
- 已对修改的文件运行 `gofmt -w` 并格式化成功。 
- 尝试运行 `go test ./internal/domain/mcp/...` 时被环境限制阻止，依赖从 `proxy.golang.org` 下载返回 `403 Forbidden`，因此单元测试无法在当前环境完成运行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699312907e40832b971a55b42d0b1efc)