### PR TITLE
恢复cosyvoice tts的选项

### DIFF
--- a/manager/frontend/src/views/admin/TTSConfig.vue
+++ b/manager/frontend/src/views/admin/TTSConfig.vue
@@ -118,6 +118,7 @@ import { Plus } from '@element-plus/icons-vue'
 import api from '../../utils/api'
 import { testSingleConfig, testWithData, parseJsonData } from '../../utils/configTest'
 import TTSConfigForm from './forms/TTSConfigForm.vue'
+import { TTS_PROVIDERS_WITH_VOICES } from './forms/ttsProviderOptions'
 
 const configs = ref([])
 const testingId = ref(null)
@@ -684,8 +685,7 @@ const loadVoiceOptions = async (provider) => {
   }
   
   // 只有这些 provider 需要从后端获取音色列表
-  const providersWithVoices = ['minimax', 'edge', 'doubao', 'doubao_ws', 'zhipu', 'openai']
-  if (!providersWithVoices.includes(provider)) {
+  if (!TTS_PROVIDERS_WITH_VOICES.includes(provider)) {
     voiceOptions.value = []
     return
   }

--- a/manager/frontend/src/views/admin/forms/TTSConfigForm.vue
+++ b/manager/frontend/src/views/admin/forms/TTSConfigForm.vue
@@ -2,13 +2,12 @@
   <el-form ref="formRef" :model="model" :rules="rules" label-width="120px">
     <el-form-item label="提供商" prop="provider">
       <el-select v-model="model.provider" placeholder="请选择提供商" style="width: 100%">
-        <el-option label="豆包 WebSocket" value="doubao_ws" />
-        <el-option label="Edge TTS" value="edge" />
-        <el-option label="Edge 离线" value="edge_offline" />
-        <el-option label="OpenAI" value="openai" />
-        <el-option label="千问" value="aliyun_qwen" />
-        <el-option label="智谱" value="zhipu" />
-        <el-option label="Minimax" value="minimax" />
+        <el-option
+          v-for="provider in TTS_PROVIDER_OPTIONS"
+          :key="provider.value"
+          :label="provider.label"
+          :value="provider.value"
+        />
       </el-select>
     </el-form-item>
     <el-form-item label="配置名称" prop="name">
@@ -269,11 +268,37 @@
         <el-input-number v-model="model.openai.frame_duration" :min="1" :max="1000" style="width: 100%" placeholder="毫秒" />
       </el-form-item>
     </template>
+
+    <template v-if="model.provider === 'cosyvoice'">
+      <el-form-item label="API URL" prop="cosyvoice.api_url">
+        <el-input v-model="model.cosyvoice.api_url" placeholder="请输入API URL" />
+      </el-form-item>
+      <el-form-item label="说话人ID" prop="cosyvoice.spk_id">
+        <el-input v-model="model.cosyvoice.spk_id" placeholder="请输入说话人ID" />
+      </el-form-item>
+      <el-form-item label="帧时长" prop="cosyvoice.frame_duration">
+        <el-input-number v-model="model.cosyvoice.frame_duration" :min="1" :max="1000" style="width: 100%" />
+      </el-form-item>
+      <el-form-item label="目标采样率" prop="cosyvoice.target_sr">
+        <el-input-number v-model="model.cosyvoice.target_sr" :min="8000" :max="48000" style="width: 100%" />
+      </el-form-item>
+      <el-form-item label="音频格式" prop="cosyvoice.audio_format">
+        <el-select v-model="model.cosyvoice.audio_format" placeholder="请选择音频格式" style="width: 100%">
+          <el-option label="MP3" value="mp3" />
+          <el-option label="WAV" value="wav" />
+          <el-option label="PCM" value="pcm" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="指示文本" prop="cosyvoice.instruct_text">
+        <el-input v-model="model.cosyvoice.instruct_text" placeholder="请输入指示文本（可选）" />
+      </el-form-item>
+    </template>
   </el-form>
 </template>
 
 <script setup>
 import { ref, computed } from 'vue'
+import { TTS_PROVIDER_OPTIONS } from './ttsProviderOptions'
 
 const props = defineProps({
   model: { type: Object, required: true },
@@ -290,6 +315,14 @@ function getJsonData() {
   const form = props.model
   const config = {}
   switch (form.provider) {
+    case 'cosyvoice':
+      config.api_url = form.cosyvoice?.api_url
+      config.spk_id = form.cosyvoice?.spk_id
+      config.frame_duration = form.cosyvoice?.frame_duration
+      config.target_sr = form.cosyvoice?.target_sr
+      config.audio_format = form.cosyvoice?.audio_format
+      config.instruct_text = form.cosyvoice?.instruct_text
+      break
     case 'doubao_ws':
       config.appid = form.doubao_ws?.appid
       config.access_token = form.doubao_ws?.access_token

--- a/manager/frontend/src/views/admin/forms/ttsProviderOptions.js
+++ b/manager/frontend/src/views/admin/forms/ttsProviderOptions.js
@@ -1,0 +1,12 @@
+export const TTS_PROVIDER_OPTIONS = [
+  { label: '豆包 WebSocket', value: 'doubao_ws' },
+  { label: 'Edge TTS', value: 'edge' },
+  { label: 'Edge 离线', value: 'edge_offline' },
+  { label: 'CosyVoice', value: 'cosyvoice' },
+  { label: 'OpenAI', value: 'openai' },
+  { label: '千问', value: 'aliyun_qwen' },
+  { label: '智谱', value: 'zhipu' },
+  { label: 'Minimax', value: 'minimax' }
+]
+
+export const TTS_PROVIDERS_WITH_VOICES = ['minimax', 'edge', 'doubao', 'doubao_ws', 'zhipu', 'openai']


### PR DESCRIPTION
### Motivation
- The TTS configuration UI had `cosyvoice` missing and saving logic lacked serialization for that provider, blocking users from adding CosyVoice configs.  
- Provider lists were maintained in multiple places which caused regressions when options were updated in one place but not others.  

### Description
- Add a centralized provider constants file `manager/frontend/src/views/admin/forms/ttsProviderOptions.js` exporting `TTS_PROVIDER_OPTIONS` and `TTS_PROVIDERS_WITH_VOICES`.  
- Update `TTSConfigForm.vue` to render the provider dropdown from `TTS_PROVIDER_OPTIONS`, add the `cosyvoice` form block (`api_url`, `spk_id`, `frame_duration`, `target_sr`, `audio_format`, `instruct_text`), and add a `getJsonData()` branch to serialize `cosyvoice` config.  
- Update `TTSConfig.vue` to import `TTS_PROVIDERS_WITH_VOICES` and use it in `loadVoiceOptions()` to determine which providers require fetching voice lists.  

### Testing
- Ran `npm run build` in `manager/frontend` and the build completed successfully.  
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the frontend started and served pages.  
- Captured a page screenshot using a Playwright script to verify the admin TTS page renders; screenshot generation succeeded.  
- Noted `http proxy error ... ECONNREFUSED 127.0.0.1:8080` during dev run due to the local backend not being started, which did not affect the frontend build or the UI changes verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699544cb1500832994eb4300ba968815)