### PR TITLE
普通用户角色 不返回敏感信息

### DIFF
--- a/manager/frontend/src/views/user/Speakers.vue
+++ b/manager/frontend/src/views/user/Speakers.vue
@@ -905,9 +905,8 @@ const handleTtsConfigChange = async (configId) => {
     currentVoiceOptions.value = response.data.data || []
   } catch (error) {
     console.error('加载音色列表失败:', error)
-    // 降级到本地提取
-    const jsonData = typeof config.json_data === 'string' ? JSON.parse(config.json_data) : config.json_data
-    currentVoiceOptions.value = extractVoiceOptions(config.provider, jsonData)
+    currentVoiceOptions.value = []
+    ElMessage.warning('加载音色列表失败，请稍后重试')
   }
 }
 


### PR DESCRIPTION
### Motivation

- 防止普通用户接口暴露 `json_data` 中可能包含的密钥/令牌等敏感信息。 
- 避免前端在后端返回失败时继续从 `json_data` 本地解析音色，降低泄露风险并提供更友好的失败提示。

### Description

- 新增 `UserConfigResponse` 结构与转换函数 `toUserConfigResponse` / `toUserConfigResponseList`，用于向普通用户返回不包含 `json_data` 的配置视图。 
- 将用户侧智能体列表与详情中内嵌的 `llm_config` / `tts_config` 类型从 `models.Config` 替换为 `UserConfigResponse` 并通过转换函数注入。 
- 将 `GetLLMConfigs` 与 `GetTTSConfigs` 接口的返回从原始 `models.Config` 列表改为安全的 `toUserConfigResponseList`。 
- 修改前端 `Speakers.vue` 的音色加载失败兜底逻辑，移除对 `config.json_data` 的本地解析，改为清空选项并用 `ElMessage.warning` 提示加载失败。

### Testing

- 在 `manager/backend` 目录执行 `go test ./controllers ./router ./middleware`，结果显示无测试文件（测试命令成功返回）。
- 在仓库根目录执行 `go test ./manager/backend/controllers ./manager/backend/router ./manager/backend/middleware` 时失败，原因是模块导入路径与执行路径不匹配（非代码变更引起的环境/路径问题）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954f1f5cc08329b7aaeb940df395fa)