### PR TITLE
fix: retry doubao ASR on response code 45000081

### DIFF
--- a/internal/data/client/asr.go
+++ b/internal/data/client/asr.go
@@ -9,6 +9,8 @@ import (
 	log "xiaozhi-esp32-server-golang/logger"
 )
 
+const doubaoRetryableResponseCode = "45000081"
+
 type Asr struct {
 	lock sync.RWMutex
 	// ASR 上下文和通道
@@ -54,6 +56,10 @@ func (a *Asr) RetireAsrResult(ctx context.Context) (string, bool, error) {
 		case result, ok := <-a.AsrResultChannel:
 			log.Debugf("asr result: %s, ok: %+v, isFinal: %+v, error: %+v", result.Text, ok, result.IsFinal, result.Error)
 			if result.Error != nil {
+				if a.AsrType == "doubao" && strings.Contains(result.Error.Error(), doubaoRetryableResponseCode) {
+					log.Warnf("doubao ASR 返回可重试错误(%s)，触发重试", doubaoRetryableResponseCode)
+					return "", true, nil
+				}
 				return "", false, result.Error
 			}
 

--- a/internal/data/client/asr_test.go
+++ b/internal/data/client/asr_test.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+	asr_types "xiaozhi-esp32-server-golang/internal/domain/asr/types"
+)
+
+func TestRetireAsrResult_DoubaoRetryableError(t *testing.T) {
+	a := &Asr{
+		AsrType:          "doubao",
+		AsrResultChannel: make(chan asr_types.StreamingResult, 1),
+	}
+	a.AsrResultChannel <- asr_types.StreamingResult{Error: errors.New("asr response code: 45000081")}
+
+	text, isRetry, err := a.RetireAsrResult(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if text != "" {
+		t.Fatalf("expected empty text, got %q", text)
+	}
+	if !isRetry {
+		t.Fatalf("expected isRetry to be true")
+	}
+}
+
+func TestRetireAsrResult_DoubaoNonRetryableError(t *testing.T) {
+	a := &Asr{
+		AsrType:          "doubao",
+		AsrResultChannel: make(chan asr_types.StreamingResult, 1),
+	}
+	a.AsrResultChannel <- asr_types.StreamingResult{Error: errors.New("asr response code: 123")}
+
+	_, isRetry, err := a.RetireAsrResult(context.Background())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if isRetry {
+		t.Fatalf("expected isRetry to be false")
+	}
+}


### PR DESCRIPTION
### Motivation
- Avoid terminating the ASR/session when Doubao ASR returns the transient error code `45000081` by treating it as retryable so the ASR loop can restart instead of returning an error.

### Description
- Add `doubaoRetryableResponseCode = "45000081"` constant and detect this code in `RetireAsrResult`; when seen for `AsrType == "doubao"` log a warning and return `("", true, nil)` to trigger a retry.  
- Keep original behavior for other errors and ASR providers.  
- Add unit tests in `internal/data/client/asr_test.go` covering the retryable `45000081` case and a non-retryable error case.  
- Run `gofmt` and commit changes.

### Testing
- Added unit tests and attempted to run `go test ./internal/data/client`.  
- Test run failed in this environment due to inability to download Go modules from `proxy.golang.org` (network/proxy restrictions returned `Forbidden`), so tests could not complete here.  
- Code compiled / formatted locally in the repository (`gofmt -w` applied) and changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996a81dbf14832991376f5528f81263)