### PR TITLE
Fix macOS ten-vad runtime loading

### DIFF
--- a/build/macos/fix_rpath.sh
+++ b/build/macos/fix_rpath.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 用于 macOS 发布包：将开发机源码绝对路径 rpath 改为相对可执行文件路径。
+# 适用目录结构：
+#   ./xiaozhi_server
+#   ./ten-vad/lib/macOS/ten_vad.framework
+
+if [[ $# -ne 1 ]]; then
+  echo "用法: $0 <xiaozhi_server二进制路径>" >&2
+  exit 1
+fi
+
+BIN_PATH="$1"
+TARGET_RPATH="@executable_path/ten-vad/lib/macOS"
+
+if [[ ! -f "$BIN_PATH" ]]; then
+  echo "二进制不存在: $BIN_PATH" >&2
+  exit 1
+fi
+
+if ! command -v otool >/dev/null 2>&1; then
+  echo "缺少 otool，请安装 Xcode Command Line Tools" >&2
+  exit 1
+fi
+
+if ! command -v install_name_tool >/dev/null 2>&1; then
+  echo "缺少 install_name_tool，请安装 Xcode Command Line Tools" >&2
+  exit 1
+fi
+
+CURRENT_RPATHS=()
+while IFS= read -r line; do
+  CURRENT_RPATHS+=("$line")
+done < <(
+  otool -l "$BIN_PATH" | awk '
+    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+    in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+  '
+)
+
+if [[ ${#CURRENT_RPATHS[@]} -eq 0 ]]; then
+  echo "未检测到 LC_RPATH，准备直接写入目标 rpath"
+fi
+
+for rpath in "${CURRENT_RPATHS[@]}"; do
+  if [[ "$rpath" == "$TARGET_RPATH" ]]; then
+    continue
+  fi
+  install_name_tool -delete_rpath "$rpath" "$BIN_PATH" 2>/dev/null || true
+done
+
+if ! otool -l "$BIN_PATH" | grep -Fq "path $TARGET_RPATH "; then
+  install_name_tool -add_rpath "$TARGET_RPATH" "$BIN_PATH"
+fi
+
+echo "已写入 rpath: $TARGET_RPATH"

--- a/doc/aio/README_macos.md
+++ b/doc/aio/README_macos.md
@@ -47,9 +47,18 @@ brew install pkg-config
 # 添加执行权限
 chmod +x xiaozhi_server
 
+# 如果这是你自己构建的发布包，先修正 rpath
+./build/macos/fix_rpath.sh ./xiaozhi_server
+
 # 启动服务
 ./xiaozhi_server
 ```
+
+说明：
+
+- 官方发布包如果已经完成打包，一般不需要再次执行 `fix_rpath.sh`
+- 只有你在源码仓库里自行构建 macOS 分发包时，才需要补这一步
+- 这一步会把二进制里的开发机绝对路径 `rpath` 改成 `@executable_path/ten-vad/lib/macOS`
 
 ### 首次运行安全提示
 
@@ -200,8 +209,23 @@ xattr -cr xiaozhi_server
 # 查看依赖
 otool -L xiaozhi_server
 
+# 查看 rpath
+otool -l xiaozhi_server | grep -A2 LC_RPATH
+
 # 确保动态库在正确位置
 ls -la ten-vad/lib/macOS/
+```
+
+如果 `LC_RPATH` 仍然是开发机源码绝对路径，而不是 `@executable_path/ten-vad/lib/macOS`，请执行：
+
+```bash
+./build/macos/fix_rpath.sh ./xiaozhi_server
+```
+
+如果你是在 IDE 临时目录调试，或手动移动了二进制导致目录结构不一致，可临时使用：
+
+```bash
+DYLD_FRAMEWORK_PATH="$PWD/ten-vad/lib/macOS" ./xiaozhi_server
 ```
 
 ### 端口被占用

--- a/doc/quickstart_bundle_tutorial.md
+++ b/doc/quickstart_bundle_tutorial.md
@@ -43,8 +43,32 @@ LD_LIBRARY_PATH="$PWD/ten-vad/lib/Linux/x64:${LD_LIBRARY_PATH:-}" ./xiaozhi_serv
 ### macOS
 ```bash
 chmod +x xiaozhi_server
+./build/macos/fix_rpath.sh ./xiaozhi_server
+./xiaozhi_server
+```
+
+如果目录结构保持为：
+
+```text
+./xiaozhi_server
+./ten-vad/lib/macOS/ten_vad.framework
+```
+
+则 macOS 包在执行过 `fix_rpath.sh` 后，默认不需要再手工设置 `DYLD_FRAMEWORK_PATH`。
+
+如果你是从 IDE 临时目录调试，或手动移动了二进制导致相对目录结构被破坏，可使用兜底方式：
+
+```bash
 DYLD_FRAMEWORK_PATH="$PWD/ten-vad/lib/macOS" ./xiaozhi_server
 ```
+
+如果你是在源码仓库里自行打 macOS 分发包，发布前需要额外执行一次：
+
+```bash
+./build/macos/fix_rpath.sh ./xiaozhi_server
+```
+
+这一步会把二进制里的 `rpath` 从开发机源码路径修正为 `@executable_path/ten-vad/lib/macOS`，让发布包在目录结构正确时直接运行。
 
 ---
 

--- a/internal/domain/vad/ten_vad/ten_vad_cgo.go
+++ b/internal/domain/vad/ten_vad/ten_vad_cgo.go
@@ -5,8 +5,8 @@ package ten_vad
 // #cgo LDFLAGS: -lm
 // #cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../../../../lib/ten-vad/lib/Windows/x64 -lten_vad
 // #cgo linux,amd64   LDFLAGS: -L${SRCDIR}/../../../../lib/ten-vad/lib/Linux/x64 -lten_vad -lc++ -lc++abi
-// #cgo darwin,amd64  LDFLAGS: -F${SRCDIR}/../../../../lib/ten-vad/lib/macOS -framework ten_vad
-// #cgo darwin,arm64  LDFLAGS: -F${SRCDIR}/../../../../lib/ten-vad/lib/macOS -framework ten_vad
+// #cgo darwin,amd64  LDFLAGS: -F${SRCDIR}/../../../../lib/ten-vad/lib/macOS -framework ten_vad -Wl,-rpath,${SRCDIR}/../../../../lib/ten-vad/lib/macOS
+// #cgo darwin,arm64  LDFLAGS: -F${SRCDIR}/../../../../lib/ten-vad/lib/macOS -framework ten_vad -Wl,-rpath,${SRCDIR}/../../../../lib/ten-vad/lib/macOS
 // #cgo windows,amd64 CFLAGS:  -I${SRCDIR}/../../../../lib/ten-vad/include
 // #cgo linux,amd64   CFLAGS:  -I${SRCDIR}/../../../../lib/ten-vad/include
 // #cgo darwin,amd64  CFLAGS:  -I${SRCDIR}/../../../../lib/ten-vad/include -F${SRCDIR}/../../../../lib/ten-vad/lib/macOS


### PR DESCRIPTION
1. 用于 macOS 发布包：将开发机源码绝对路径 rpath 改为相对可执行文件路径。
2. 修复开发、调试时无法找到引用的问题