### PR TITLE
feat(asr): 支持配置豆包 ASR 资源规格

### DIFF
--- a/internal/domain/asr/doubao/adapter.go
+++ b/internal/domain/asr/doubao/adapter.go
@@ -29,6 +29,9 @@ func NewDoubaoV2Adapter(config map[string]interface{}) (*DoubaoV2Adapter, error)
 	if wsURL, ok := config["ws_url"].(string); ok && wsURL != "" {
 		doubaoConfig.WsURL = wsURL
 	}
+	if resourceID, ok := config["resource_id"].(string); ok && resourceID != "" {
+		doubaoConfig.ResourceID = resourceID
+	}
 	if modelName, ok := config["model_name"].(string); ok && modelName != "" {
 		doubaoConfig.ModelName = modelName
 	}

--- a/internal/domain/asr/doubao/client/client_stream.go
+++ b/internal/domain/asr/doubao/client/client_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -17,12 +18,13 @@ import (
 )
 
 type AsrWsClient struct {
-	seq       int
-	url       string
-	connect   *websocket.Conn
-	appId     string
-	accessKey string
-	mu        sync.RWMutex // Protects connect from concurrent access
+	seq        int
+	url        string
+	connect    *websocket.Conn
+	appId      string
+	accessKey  string
+	resourceID string
+	mu         sync.RWMutex // Protects connect from concurrent access
 
 	// 延迟连接相关字段
 	connectOnce  sync.Once     // 确保连接只建立一次
@@ -31,20 +33,32 @@ type AsrWsClient struct {
 	connectErrMu sync.Mutex    // 保护 connectErr
 }
 
-func NewAsrWsClient(url string, appKey, accessKey string) *AsrWsClient {
+func NewAsrWsClient(url string, appKey, accessKey, resourceID string) *AsrWsClient {
 	return &AsrWsClient{
 		seq:          1,
 		url:          url,
 		appId:        appKey,
 		accessKey:    accessKey,
+		resourceID:   resourceID,
 		connectReady: make(chan struct{}),
 	}
 }
 
 func (c *AsrWsClient) CreateConnection(ctx context.Context) error {
-	header := request.NewAuthHeader(c.appId, c.accessKey)
+	header := request.NewAuthHeader(c.appId, c.accessKey, c.resourceID)
 	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, c.url, header)
 	if err != nil {
+		if resp != nil {
+			var body string
+			if resp.Body != nil {
+				bodyBytes, readErr := io.ReadAll(resp.Body)
+				_ = resp.Body.Close()
+				if readErr == nil {
+					body = string(bodyBytes)
+				}
+			}
+			return fmt.Errorf("dial websocket err: %w, status=%d, body=%s", err, resp.StatusCode, body)
+		}
 		return fmt.Errorf("dial websocket err: %w", err)
 	}
 	_ = resp
@@ -262,8 +276,6 @@ func (c *AsrWsClient) recvMessages(ctx context.Context, resChan chan<- *response
 func (c *AsrWsClient) StartAudioStream(ctx context.Context, audioStream <-chan []float32, resChan chan<- *response.AsrResponse) error {
 	stopChan := make(chan struct{})
 	sendDoneChan := make(chan error, 1) // 发送完成通知（nil表示正常完成，error表示出错）
-
-	defer close(resChan)
 
 	// 启动发送 goroutine
 	go func() {

--- a/internal/domain/asr/doubao/doubao.go
+++ b/internal/domain/asr/doubao/doubao.go
@@ -43,6 +43,9 @@ func NewDoubaoV2ASR(config DoubaoV2Config) (*DoubaoV2ASR, error) {
 	if config.WsURL == "" {
 		config.WsURL = DefaultConfig.WsURL
 	}
+	if config.ResourceID == "" {
+		config.ResourceID = DefaultConfig.ResourceID
+	}
 	if config.ModelName == "" {
 		config.ModelName = DefaultConfig.ModelName
 	}
@@ -68,7 +71,7 @@ func NewDoubaoV2ASR(config DoubaoV2Config) (*DoubaoV2ASR, error) {
 // 注意：连接将在收到第一个音频包时延迟建立，避免因VAD延迟导致服务端超时
 func (d *DoubaoV2ASR) StreamingRecognize(ctx context.Context, audioStream <-chan []float32) (chan types.StreamingResult, error) {
 	// 创建客户端实例（不立即建立连接）
-	d.c = client.NewAsrWsClient(d.config.WsURL, d.config.AppID, d.config.AccessToken)
+	d.c = client.NewAsrWsClient(d.config.WsURL, d.config.AppID, d.config.AccessToken, d.config.ResourceID)
 
 	// 豆包返回的识别结果
 	doubaoResultChan := make(chan *response.AsrResponse, 10)
@@ -77,7 +80,19 @@ func (d *DoubaoV2ASR) StreamingRecognize(ctx context.Context, audioStream <-chan
 
 	// 启动音频流处理（连接将在第一个音频包到达时建立）
 	go func() {
-		d.c.StartAudioStream(ctx, audioStream, doubaoResultChan)
+		defer close(doubaoResultChan)
+		if err := d.c.StartAudioStream(ctx, audioStream, doubaoResultChan); err != nil {
+			payload := &response.AsrResponsePayload{}
+			payload.Error = err.Error()
+			select {
+			case <-ctx.Done():
+			case doubaoResultChan <- &response.AsrResponse{
+				Code:          -1,
+				IsLastPackage: true,
+				PayloadMsg:    payload,
+			}:
+			}
+		}
 	}()
 
 	// 启动结果接收goroutine
@@ -102,10 +117,13 @@ func (d *DoubaoV2ASR) receiveStreamResults(ctx context.Context, resultChan chan 
 		case result, ok := <-asrResponseChan:
 			if !ok {
 				log.Debugf("receiveStreamResults asrResponseChan 已关闭")
-				// 静音情况：连接未建立，asrResponseChan 被关闭，直接返回
 				return
 			}
 			if result.Code != 0 {
+				errMsg := fmt.Sprintf("asr response code: %d", result.Code)
+				if result.PayloadMsg != nil && result.PayloadMsg.Error != "" {
+					errMsg = result.PayloadMsg.Error
+				}
 				// 使用 select 避免向已关闭的 channel 发送（如果 ctx 已取消，优先选择 ctx.Done()）
 				select {
 				case <-ctx.Done():
@@ -114,7 +132,7 @@ func (d *DoubaoV2ASR) receiveStreamResults(ctx context.Context, resultChan chan 
 				case resultChan <- types.StreamingResult{
 					Text:    "",
 					IsFinal: true,
-					Error:   fmt.Errorf("asr response code: %d", result.Code),
+					Error:   fmt.Errorf("%s", errMsg),
 				}:
 				}
 				return

--- a/internal/domain/asr/doubao/request/header.go
+++ b/internal/domain/asr/doubao/request/header.go
@@ -61,11 +61,11 @@ func DefaultHeader() *AsrRequestHeader {
 	}
 }
 
-func NewAuthHeader(appKey, accessKey string) http.Header {
+func NewAuthHeader(appKey, accessKey, resourceID string) http.Header {
 	reqid := uuid.New().String()
 	header := http.Header{}
 
-	header.Add("X-Api-Resource-Id", "volc.bigasr.sauc.duration")
+	header.Add("X-Api-Resource-Id", resourceID)
 	header.Add("X-Api-Request-Id", reqid)
 	header.Add("X-Api-Access-Key", accessKey)
 	header.Add("X-Api-App-Key", appKey)

--- a/internal/domain/asr/doubao/types.go
+++ b/internal/domain/asr/doubao/types.go
@@ -5,6 +5,7 @@ type DoubaoV2Config struct {
 	AppID         string // 应用ID
 	AccessToken   string // 访问令牌
 	WsURL         string // WebSocket URL
+	ResourceID    string // 资源ID
 	ModelName     string // 模型名称
 	EndWindowSize int    // 结束窗口大小
 	EnablePunc    bool   // 是否启用标点符号
@@ -17,6 +18,7 @@ type DoubaoV2Config struct {
 // DefaultConfig 默认配置
 var DefaultConfig = DoubaoV2Config{
 	WsURL:         "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream",
+	ResourceID:    "volc.bigasr.sauc.duration",
 	ModelName:     "bigmodel",
 	EndWindowSize: 800,
 	EnablePunc:    true,

--- a/manager/frontend/src/views/admin/ASRConfig.vue
+++ b/manager/frontend/src/views/admin/ASRConfig.vue
@@ -87,7 +87,7 @@
     <el-dialog
       v-model="showDialog"
       :title="editingConfig ? '编辑ASR配置' : '添加ASR配置'"
-      width="600px"
+      width="720px"
       @close="handleDialogClose"
     >
       <ASRConfigForm ref="formRef" :model="form" :rules="rules" />
@@ -235,7 +235,7 @@ const rules = computed(() => {
       'doubao.appid': [{ required: true, message: '请输入应用ID', trigger: 'blur' }],
       'doubao.access_token': [{ required: true, message: '请输入访问令牌', trigger: 'blur' }],
       'doubao.ws_url': [{ required: true, message: '请输入WebSocket URL', trigger: 'blur' }],
-      'doubao.model_name': [{ required: true, message: '请输入模型名称', trigger: 'blur' }],
+      'doubao.resource_id': [{ required: true, message: '请选择资源规格', trigger: 'change' }],
       'doubao.end_window_size': [{ required: true, message: '请输入结束窗口大小', trigger: 'blur' }],
       'doubao.timeout': [{ required: true, message: '请输入超时时间', trigger: 'blur' }]
     }
@@ -551,6 +551,7 @@ const resetForm = () => {
     appid: '',
     access_token: '',
     ws_url: 'wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream',
+    resource_id: 'volc.bigasr.sauc.duration',
     model_name: 'bigmodel',
     end_window_size: 800,
     enable_punc: true,

--- a/manager/frontend/src/views/admin/ConfigWizard.vue
+++ b/manager/frontend/src/views/admin/ConfigWizard.vue
@@ -168,6 +168,7 @@ import VADConfigForm from './forms/VADConfigForm.vue'
 import ASRConfigForm from './forms/ASRConfigForm.vue'
 import LLMConfigForm from './forms/LLMConfigForm.vue'
 import TTSConfigForm from './forms/TTSConfigForm.vue'
+import { getProviderFixedType, isProviderBaseURLEditable, resolveLLMProvider } from './forms/llmCatalog'
 
 const currentStep = ref(0)
 const saving = ref(false)
@@ -257,6 +258,7 @@ const asrForm = reactive({
     appid: '',
     access_token: '',
     ws_url: 'wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream',
+    resource_id: 'volc.bigasr.sauc.duration',
     model_name: 'bigmodel',
     end_window_size: 800,
     enable_punc: true,
@@ -313,7 +315,7 @@ const asrFormRules = {
   'doubao.appid': [{ required: true, message: '请输入应用ID', trigger: 'blur' }],
   'doubao.access_token': [{ required: true, message: '请输入访问令牌', trigger: 'blur' }],
   'doubao.ws_url': [{ required: true, message: '请输入WebSocket URL', trigger: 'blur' }],
-  'doubao.model_name': [{ required: true, message: '请输入模型名称', trigger: 'blur' }],
+  'doubao.resource_id': [{ required: true, message: '请选择资源规格', trigger: 'change' }],
   'aliyun_qwen3.ws_url': [{ required: true, message: '请输入WS URL', trigger: 'blur' }],
   'aliyun_qwen3.model': [{ required: true, message: '请输入模型名称', trigger: 'blur' }],
   'aliyun_qwen3.format': [{ required: true, message: '请选择音频格式', trigger: 'change' }],
@@ -332,18 +334,67 @@ const llmForm = reactive({
   base_url: 'https://api.openai.com/v1',
   max_tokens: 4000,
   temperature: 0.7,
-  top_p: 0.9
+  top_p: 0.9,
+  thinking_mode: 'default',
+  thinking_budget_tokens: null,
+  thinking_effort: 'medium',
+  thinking_clear_thinking: 'default'
 })
 const llmFormRef = ref()
 const llmFormRules = {
   name: [{ required: true, message: '请输入配置名称', trigger: 'blur' }],
   config_id: [{ required: true, message: '请输入配置ID', trigger: 'blur' }],
-  provider: [{ required: false }],
-  type: [{ required: true, message: '请选择模型类型', trigger: 'change' }],
-  model_name: [{ required: true, message: '请输入模型名称', trigger: 'blur' }],
-  api_key: [{ required: true, message: '请输入API密钥', trigger: 'blur' }],
-  base_url: [{ required: true, message: '请输入基础URL', trigger: 'blur' }],
-  max_tokens: [{ required: true, message: '请输入max_tokens', trigger: 'blur' }]
+  provider: [{ required: true, message: '请选择提供商', trigger: 'change' }],
+  model_name: [{
+    required: true,
+    message: '请输入模型名称',
+    trigger: 'change'
+  }, {
+    validator: (_, value, callback) => {
+      const provider = resolveLLMProvider(llmForm.provider, llmForm.type)
+      const providerType = getProviderFixedType(provider)
+      if ((providerType === 'openai' || providerType === 'ollama') && !value) {
+        callback(new Error('请输入模型名称'))
+        return
+      }
+      callback()
+    },
+    trigger: 'change'
+  }],
+  api_key: [{
+    validator: (_, value, callback) => {
+      const provider = resolveLLMProvider(llmForm.provider, llmForm.type)
+      if (getProviderFixedType(provider) !== 'ollama' && !value) {
+        callback(new Error('请输入API密钥'))
+        return
+      }
+      callback()
+    },
+    trigger: 'blur'
+  }],
+  base_url: [{
+    validator: (_, value, callback) => {
+      const provider = resolveLLMProvider(llmForm.provider, llmForm.type)
+      if (isProviderBaseURLEditable(provider) && !value) {
+        callback(new Error('请输入基础URL'))
+        return
+      }
+      callback()
+    },
+    trigger: 'blur'
+  }],
+  max_tokens: [{
+    validator: (_, value, callback) => {
+      const provider = resolveLLMProvider(llmForm.provider, llmForm.type)
+      const providerType = getProviderFixedType(provider)
+      if ((providerType === 'openai' || providerType === 'ollama') && (!value || Number(value) < 1 || Number(value) > 100000)) {
+        callback(new Error('max_tokens必须在1-100000之间'))
+        return
+      }
+      callback()
+    },
+    trigger: 'blur'
+  }]
 }
 
 const ttsForm = reactive({
@@ -796,15 +847,20 @@ async function loadLlmIfExists() {
     llmConfigId.value = config.id
     llmForm.name = config.name
     llmForm.config_id = config.config_id
-    llmForm.provider = config.provider || 'openai'
     const data = JSON.parse(config.json_data || '{}')
-    if (data.type !== undefined) llmForm.type = data.type
+    const detectedProvider = resolveLLMProvider(config.provider, data.type)
+    llmForm.provider = detectedProvider
+    llmForm.type = getProviderFixedType(detectedProvider)
     if (data.model_name !== undefined) llmForm.model_name = data.model_name
     if (data.api_key !== undefined) llmForm.api_key = data.api_key
     if (data.base_url !== undefined) llmForm.base_url = data.base_url
     if (data.max_tokens !== undefined) llmForm.max_tokens = data.max_tokens
     if (data.temperature !== undefined) llmForm.temperature = data.temperature
     if (data.top_p !== undefined) llmForm.top_p = data.top_p
+    if (data.thinking?.mode !== undefined) llmForm.thinking_mode = data.thinking.mode
+    if (data.thinking?.budget_tokens !== undefined) llmForm.thinking_budget_tokens = Number(data.thinking.budget_tokens) || null
+    if (data.thinking?.effort !== undefined) llmForm.thinking_effort = data.thinking.effort
+    if (data.thinking?.clear_thinking !== undefined) llmForm.thinking_clear_thinking = data.thinking.clear_thinking
   } catch (_) {}
 }
 
@@ -869,7 +925,14 @@ function prevStep() {
 
 function formatTestMessage(result) {
   const base = result.message || ''
-  return result.first_packet_ms != null ? `${base} ${result.first_packet_ms}ms` : base
+  const suffix = []
+  if (result.first_packet_ms != null) suffix.push(`${result.first_packet_ms}ms`)
+  if (result.reasoning_content_returned) suffix.push('检测到上游返回思考内容')
+  return suffix.length ? `${base} ${suffix.join(' · ')}` : base
+}
+
+function formatDraftTestLabel(name, configId) {
+  return name?.trim() || configId?.trim() || '当前配置'
 }
 
 async function testCurrentStepConfig() {
@@ -892,8 +955,9 @@ async function testCurrentStepConfig() {
     testingStep.value = true
     try {
       const result = await testWithData('vad', { [configId]: payload })
-      if (result.ok) ElMessage.success(formatTestMessage(result) || '测试通过')
-      else ElMessage.warning(result.message || '测试未通过')
+      const label = formatDraftTestLabel(vadForm.name, configId)
+      if (result.ok) ElMessage.success(`${label}：${formatTestMessage(result) || '测试通过'}`)
+      else ElMessage.warning(`${label}：${result.message || '测试未通过'}`)
     } catch (err) {
       ElMessage.warning(err.response?.data?.error || '测试请求失败')
     } finally {
@@ -919,8 +983,9 @@ async function testCurrentStepConfig() {
     testingStep.value = true
     try {
       const result = await testWithData('asr', { [configId]: payload })
-      if (result.ok) ElMessage.success(formatTestMessage(result) || '测试通过')
-      else ElMessage.warning(result.message || '测试未通过')
+      const label = formatDraftTestLabel(asrForm.name, configId)
+      if (result.ok) ElMessage.success(`${label}：${formatTestMessage(result) || '测试通过'}`)
+      else ElMessage.warning(`${label}：${result.message || '测试未通过'}`)
     } catch (err) {
       ElMessage.warning(err.response?.data?.error || '测试请求失败')
     } finally {
@@ -945,9 +1010,10 @@ async function testCurrentStepConfig() {
     }
     testingStep.value = true
     try {
-      const result = await testWithData('llm', { [configId]: payload })
-      if (result.ok) ElMessage.success(formatTestMessage(result) || '测试通过')
-      else ElMessage.warning(result.message || '测试未通过')
+      const result = await testWithData('llm', { provider: configId, [configId]: payload })
+      const label = formatDraftTestLabel(llmForm.name, configId)
+      if (result.ok) ElMessage.success(`${label}：${formatTestMessage(result) || '测试通过'}`)
+      else ElMessage.warning(`${label}：${result.message || '测试未通过'}`)
     } catch (err) {
       ElMessage.warning(err.response?.data?.error || '测试请求失败')
     } finally {
@@ -973,8 +1039,9 @@ async function testCurrentStepConfig() {
     testingStep.value = true
     try {
       const result = await testWithData('tts', { [configId]: payload })
-      if (result.ok) ElMessage.success(formatTestMessage(result) || '测试通过')
-      else ElMessage.warning(result.message || '测试未通过')
+      const label = formatDraftTestLabel(ttsForm.name, configId)
+      if (result.ok) ElMessage.success(`${label}：${formatTestMessage(result) || '测试通过'}`)
+      else ElMessage.warning(`${label}：${result.message || '测试未通过'}`)
     } catch (err) {
       ElMessage.warning(err.response?.data?.error || '测试请求失败')
     } finally {
@@ -1154,7 +1221,7 @@ onMounted(async () => {
 <style scoped>
 .config-wizard {
   padding: 20px;
-  max-width: 720px;
+  max-width: 820px;
   margin: 0 auto;
 }
 .wizard-header {

--- a/manager/frontend/src/views/admin/forms/ASRConfigForm.vue
+++ b/manager/frontend/src/views/admin/forms/ASRConfigForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-form ref="formRef" :model="model" :rules="rules" label-width="120px">
+  <el-form ref="formRef" :model="model" :rules="rules" label-width="140px">
     <el-form-item label="提供商" prop="provider">
       <el-select v-model="model.provider" placeholder="请选择提供商" style="width: 100%" @change="onProviderChange">
         <el-option label="FunASR" value="funasr" />
@@ -108,8 +108,13 @@
       <el-form-item label="WebSocket URL" prop="doubao.ws_url">
         <el-input v-model="model.doubao.ws_url" placeholder="请输入WebSocket URL" />
       </el-form-item>
-      <el-form-item label="模型名称" prop="doubao.model_name">
-        <el-input v-model="model.doubao.model_name" placeholder="请输入模型名称" />
+      <el-form-item label="资源规格" prop="doubao.resource_id">
+        <el-select v-model="model.doubao.resource_id" placeholder="请选择资源规格" style="width: 100%">
+          <el-option label="豆包流式语音识别模型1.0 小时版" value="volc.bigasr.sauc.duration" />
+          <el-option label="豆包流式语音识别模型1.0 并发版" value="volc.bigasr.sauc.concurrent" />
+          <el-option label="豆包流式语音识别模型2.0 小时版" value="volc.seedasr.sauc.duration" />
+          <el-option label="豆包流式语音识别模型2.0 并发版" value="volc.seedasr.sauc.concurrent" />
+        </el-select>
       </el-form-item>
       <el-form-item label="结束窗口大小" prop="doubao.end_window_size">
         <el-input-number v-model="model.doubao.end_window_size" :min="1" style="width: 100%" />


### PR DESCRIPTION
- 新增豆包 ASR resource_id 配置并透传到 X-Api-Resource-Id 请求头
- 管理页和配置向导为豆包 ASR 增加中文资源规格下拉选项
- 为豆包 ASR 补充资源规格默认值和必填校验
- 修复豆包 ASR 建连失败时测试结果误判为通过的问题
- 透传 WebSocket 握手失败的状态码和响应体
- 修复豆包 ASR 错误透传导致的 closed channel panic