### PR TITLE
Fix MySQL key length by shrinking MCPMarketService.URLHash to char(64)

### DIFF
--- a/manager/backend/models/models.go
+++ b/manager/backend/models/models.go
@@ -132,7 +132,7 @@ type MCPMarketService struct {
 	Enabled     bool   `json:"enabled" gorm:"default:true;index"`
 	Transport   string `json:"transport" gorm:"type:varchar(32);not null"` // sse / streamablehttp
 	URL         string `json:"url" gorm:"type:text;not null"`
-	URLHash     string `json:"url_hash" gorm:"type:varchar(512);not null;uniqueIndex:idx_mcp_market_services_url_hash"`
+	URLHash     string `json:"url_hash" gorm:"type:char(64);not null;uniqueIndex:idx_mcp_market_services_url_hash"` // sha256(url) hex
 	HeadersJSON string `json:"headers_json" gorm:"type:text"`
 
 	MarketID    *uint  `json:"market_id" gorm:"index"` // 关联 configs(type=mcp_market).id


### PR DESCRIPTION
### Motivation

- Auto-migration failed on some MySQL/InnoDB setups with "Specified key was too long" because the `url_hash` unique index used `varchar(512)` with `utf8mb4` encoding which can exceed InnoDB key length limits. 
- The code already computes the hash as a SHA-256 hex string, which is exactly 64 characters, so a fixed `char(64)` is sufficient and avoids oversized index keys.

### Description

- Change `MCPMarketService.URLHash` column definition from `varchar(512)` to `char(64)` in `manager/backend/models/models.go` and add an inline comment that it stores the hex-encoded SHA-256 of the normalized URL.
- The new field tag is `gorm:"type:char(64);not null;uniqueIndex:idx_mcp_market_services_url_hash"` to keep the unique index while guaranteeing index length fits older MySQL limits.
- No other schema or hash-generation logic was modified, and the change matches the existing `normalizedURLHash` SHA-256 hex output.

### Testing

- Ran `go test ./manager/backend/...` which failed because the main module path structure prevented that package pattern from being resolved in this environment (setup error). 
- Ran `go test ./...` which was blocked by dependency fetch failures from `proxy.golang.org` returning HTTP 403 in this environment, preventing full test execution. 
- Ran `timeout 20s bash -lc 'cd manager/backend && go test ./...'` which produced no useful output before timing out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcb7c53a84832bb4c2031acfaba17b)