### PR TITLE
Fix TTS sentence splitting for time strings

### DIFF
--- a/internal/util/sentence.go
+++ b/internal/util/sentence.go
@@ -184,6 +184,27 @@ func trimSpaceRunes(text []rune) []rune {
 	return text[start : end+1]
 }
 
+func isDigitAdjacentColon(text []rune, pos int) bool {
+	if pos < 0 || pos >= len(text) {
+		return false
+	}
+
+	colon := text[pos]
+	if colon != ':' && colon != '：' {
+		return false
+	}
+
+	if pos == 0 || !unicode.IsDigit(text[pos-1]) {
+		return false
+	}
+
+	if pos == len(text)-1 {
+		return true
+	}
+
+	return unicode.IsDigit(text[pos+1])
+}
+
 // findLastPunctuation 从后向前查找最后一个标点
 func findLastPunctuation(text []rune, separatorMap map[rune]bool) int {
 	lastPos := -1
@@ -192,6 +213,9 @@ func findLastPunctuation(text []rune, separatorMap map[rune]bool) int {
 		if separatorMap[text[i]] {
 			// 如果是点号，检查是否是序号的一部分
 			if text[i] == '.' && isNumberPrefix(text, i) {
+				continue
+			}
+			if isDigitAdjacentColon(text, i) {
 				continue
 			}
 			return i
@@ -226,6 +250,9 @@ func findNextSplitPoint(text []rune, startPos int, maxLen int, separatorMap map[
 
 		// 使用map检查是否是标点符号
 		if separatorMap[text[i]] {
+			if isDigitAdjacentColon(text, i) {
+				continue
+			}
 			return i
 		}
 	}
@@ -233,7 +260,13 @@ func findNextSplitPoint(text []rune, startPos int, maxLen int, separatorMap map[
 	// 如果在maxLen范围内没找到，尝试在更大范围内查找
 	if endPos < len(text) {
 		for i := endPos; i < len(text); i++ {
-			if text[i] == '\n' || separatorMap[text[i]] {
+			if text[i] == '\n' {
+				return i
+			}
+			if separatorMap[text[i]] {
+				if isDigitAdjacentColon(text, i) {
+					continue
+				}
 				return i
 			}
 		}
@@ -323,16 +356,21 @@ func ExtractSmartSentences(text string, minLen, maxLen int, isFirst bool) (sente
 
 // ContainsSentenceSeparator 判断字符串中是否包含分隔符（句子结束或暂停标点符号）
 func ContainsSentenceSeparator(s string, isFirst bool) bool {
-	for _, r := range s {
-		if isFirst {
-			if firstPunctuation[r] {
-				return true
-			}
-		} else {
-			if punctuationMap[r] {
-				return true
-			}
-		}
+	separatorMap := punctuationMap
+	if isFirst {
+		separatorMap = firstPunctuation
 	}
+
+	runes := []rune(s)
+	for i, r := range runes {
+		if !separatorMap[r] {
+			continue
+		}
+		if isDigitAdjacentColon(runes, i) {
+			continue
+		}
+		return true
+	}
+
 	return false
 }

--- a/internal/util/sentence_test.go
+++ b/internal/util/sentence_test.go
@@ -1,0 +1,29 @@
+package util
+
+import "testing"
+
+func TestExtractSmartSentencesKeepsTimeTogether(t *testing.T) {
+	text := "根据系统时间，现在是2026年3月20日 星期五 02:37:04。"
+
+	sentences, remaining := ExtractSmartSentences(text, 2, 100, false)
+
+	if remaining != "" {
+		t.Fatalf("expected no remaining text, got %q", remaining)
+	}
+	if len(sentences) != 1 {
+		t.Fatalf("expected 1 sentence, got %d: %#v", len(sentences), sentences)
+	}
+	if sentences[0] != text {
+		t.Fatalf("expected full time expression to stay intact, got %q", sentences[0])
+	}
+}
+
+func TestContainsSentenceSeparatorIgnoresStreamingTimeColon(t *testing.T) {
+	if ContainsSentenceSeparator("现在是2026年3月20日 星期五 02:", false) {
+		t.Fatal("expected trailing time colon not to trigger sentence split")
+	}
+
+	if !ContainsSentenceSeparator("现在是2026年3月20日 星期五 02:37:04。", false) {
+		t.Fatal("expected final period to trigger sentence split")
+	}
+}


### PR DESCRIPTION
### Motivation
- Streaming LLM/TTS output was splitting numeric time tokens like `02:37:04` into fragments (e.g. `02:`, `37:`, `04`) which caused awkward TTS playback and sentence events.
- Improve sentence-splitting logic to treat colons in digit-adjacent contexts as non-separators so time expressions remain intact during streaming.

### Description
- Added a helper `isDigitAdjacentColon` to detect `:` / `：` characters that are adjacent to digits and likely part of a time token in `internal/util/sentence.go`.
- Updated `findLastPunctuation` and `findNextSplitPoint` to skip colon separators when `isDigitAdjacentColon` returns true so split points are not placed inside time strings.
- Reworked `ContainsSentenceSeparator` to consider the new helper and avoid reporting a separator for streaming fragments like a trailing `02:`.
- Added unit tests in `internal/util/sentence_test.go` to assert that full time expressions stay as a single sentence and that a trailing streaming colon does not prematurely trigger a sentence split.

### Testing
- Ran package tests for the modified util file with `cd internal/util && env GO111MODULE=off go test sentence.go sentence_test.go -v`, and the new tests passed.
- Attempted `go test ./internal/util` but full module-level test run failed in this environment due to inability to download dependencies from `proxy.golang.org` (module proxy restrictions), so broader package tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcba4cabd8832b82e5cc937336655f)