### PR TITLE
Relax handleToolResult JSON parsing

### DIFF
--- a/doc/mcp_resource.md
+++ b/doc/mcp_resource.md
@@ -330,6 +330,11 @@ if mcpResp, ok := l.handleLocalToolResult(fcResult); ok {
 }
 ```
 
+> `handleToolResult` **不再要求工具返回值必须是 JSON**。  
+> - 如果返回的是标准 MCP `CallToolResult` JSON，会按结构化内容解析。  
+> - 如果返回的是普通字符串，会自动包装成 `TextContent` 继续后续流程。  
+> 这样普通文本工具和结构化 MCP 工具都可以被统一处理。
+
 ### 3. 内容类型处理
 ```go
 for _, content := range contentList {

--- a/internal/app/server/chat/llm.go
+++ b/internal/app/server/chat/llm.go
@@ -879,8 +879,14 @@ func (l *LLMManager) handleLocalToolResult(toolResult string) (MCPResponse, bool
 func (l *LLMManager) handleToolResult(toolResultStr string) (mcp_go.CallToolResult, bool) {
 	var toolResult mcp_go.CallToolResult
 	if err := json.Unmarshal([]byte(toolResultStr), &toolResult); err != nil {
-		log.Errorf("解析工具结果失败: %v", err)
-		return toolResult, false
+		log.Warnf("工具结果不是标准 MCP JSON，按纯文本处理: %v", err)
+		toolResult.Content = []mcp_go.Content{
+			mcp_go.TextContent{
+				Type: "text",
+				Text: toolResultStr,
+			},
+		}
+		return toolResult, true
 	}
 
 	return toolResult, true

--- a/internal/app/server/chat/llm_test.go
+++ b/internal/app/server/chat/llm_test.go
@@ -1,0 +1,55 @@
+package chat
+
+import (
+	"testing"
+
+	mcp_go "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestHandleToolResultAcceptsPlainText(t *testing.T) {
+	manager := &LLMManager{}
+
+	result, ok := manager.handleToolResult("普通文本返回")
+	if !ok {
+		t.Fatal("expected plain text tool result to be accepted")
+	}
+
+	if result.IsError {
+		t.Fatal("expected plain text tool result not to be marked as error")
+	}
+
+	if len(result.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Content))
+	}
+
+	textContent, ok := result.Content[0].(mcp_go.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+
+	if textContent.Text != "普通文本返回" {
+		t.Fatalf("expected original text to be preserved, got %q", textContent.Text)
+	}
+}
+
+func TestHandleToolResultAcceptsMCPJSON(t *testing.T) {
+	manager := &LLMManager{}
+
+	result, ok := manager.handleToolResult(`{"content":[{"type":"text","text":"json返回"}],"isError":false}`)
+	if !ok {
+		t.Fatal("expected MCP JSON tool result to be accepted")
+	}
+
+	if len(result.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Content))
+	}
+
+	textContent, ok := result.Content[0].(mcp_go.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+
+	if textContent.Text != "json返回" {
+		t.Fatalf("expected parsed text content, got %q", textContent.Text)
+	}
+}


### PR DESCRIPTION
### Motivation

- `handleToolResult` currently treats non-JSON tool outputs as parse failures, which prevents simple plain-text tools from being consumed.
- The intent is to accept both structured MCP JSON and plain string returns so ordinary tools can be used without forcing JSON formatting.

### Description

- Update `handleToolResult` in `internal/app/server/chat/llm.go` to treat non-JSON returns as plain text by wrapping the original string into a `mcp_go.TextContent` and returning a populated `mcp_go.CallToolResult` instead of failing.
- Add unit tests in `internal/app/server/chat/llm_test.go` covering both plain-text returns and standard MCP JSON parsing to validate the new behavior.
- Update `doc/mcp_resource.md` to document that `handleToolResult` no longer requires JSON and that plain strings are automatically converted to `TextContent`.

### Testing

- Ran `gofmt -w internal/app/server/chat/llm.go internal/app/server/chat/llm_test.go`, which completed successfully.
- Ran `go test ./internal/app/server/chat/...`, which could not complete in this environment because downloading Go modules from `proxy.golang.org` returned HTTP 403 Forbidden; the new unit tests are included but full execution was blocked by the module download failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcc1e0af44832baae6fff392179647)