### PR TITLE
Chat Hook V2: async runtime, plugin meta/registry/lifecycle, and builtin statistic plugin

### DIFF
--- a/ai_doc/chat_hook_plugin_v2_design.md
+++ b/ai_doc/chat_hook_plugin_v2_design.md
@@ -1,0 +1,704 @@
+# Chat Hook / Plugin V2 设计文档
+
+## 1. 文档目标
+
+本文档用于回答三个问题：
+
+1. 当前聊天链路 Hook 架构的合理边界是什么；
+2. V2 应该优先补哪些能力；
+3. 在尽量不扰动现有业务主链路的前提下，如何分阶段演进。
+
+本文档的定位不是“构建一个完整插件市场”，而是为当前仓库落地一套**可治理、可扩展、可观测**的 Chat Hook / Plugin V2 方案。
+
+---
+
+## 2. TL;DR
+
+### 2.1 一句话结论
+
+当前实现已经具备一个可用的 **Chat Hook Framework** 雏形，但还不适合直接定义为“完整 Plugin Platform”。
+
+### 2.2 V2 核心主张
+
+V2 的核心不是“推翻重写”，而是：
+
+- 保留现有业务接入点；
+- 将 **Interceptor（可改写主流程）** 与 **Observer（只做观测）** 明确拆分；
+- 为异步执行补齐 **有界队列、超时、丢弃策略、指标**；
+- 引入 **PluginMeta + Registry + Lifecycle**；
+- 为 ASR / LLM / TTS / Metric 事件补齐契约。
+
+### 2.3 推荐优先级
+
+| 优先级 | 建议项 | 目标 |
+| --- | --- | --- |
+| P0 | Async Runtime 治理 | 防止慢插件拖垮系统 |
+| P0 | Interceptor / Observer 语义拆分 | 降低语义混用 |
+| P0 | Payload 契约文档 | 降低插件误用 |
+| P1 | PluginMeta / Registry | 让插件注册可管理 |
+| P1 | Lifecycle / Config | 支持带状态插件 |
+| P2 | 多队列 / 多 worker / tracing 集成 | 支持更复杂扩展 |
+
+---
+
+## 3. 现状判断
+
+## 3.1 当前设计已经做对的部分
+
+当前实现已经具备以下优点：
+
+1. **接入点选得对**
+   - Hook 已经接在 ASR 最终输出、LLM 输入/输出、TTS 输入/输出起止、Metric 阶段；
+   - 都是聊天主链路中最有业务价值的位置。
+
+2. **分层基本正确**
+   - `internal/pkg/hooks` 负责通用执行框架；
+   - `internal/domain/chat/hooks` 负责 chat 领域上下文、事件和 typed payload；
+   - `internal/app/server/chat/*` 只负责在合适的位置 emit。
+
+3. **Typed façade 已经建立**
+   - 业务侧已经不是直接操作 `any`；
+   - 这为 V2 继续增强契约与治理提供了良好基础。
+
+4. **可插拔性已经可用**
+   - 当前已经能支撑统计插件、文本改写、流程拦截等内建能力。
+
+## 3.2 当前主要短板
+
+当前最需要解决的不是“抽象不对”，而是“治理能力不足”。
+
+### A. 语义混用
+
+当前统一用一套 Hook 模型承载两类完全不同的需求：
+
+- 可改写主流程的拦截器；
+- 只做观测的 metric / audit / telemetry。
+
+这会带来以下问题：
+
+- `stop` 语义并不适合所有事件；
+- `payload 改写` 只适合一部分阶段；
+- 插件作者不容易理解哪些事件能做什么。
+
+### B. 异步执行治理不足
+
+当前 async 执行的痛点：
+
+- 队列无上限；
+- 缺少 timeout；
+- 缺少 dropped 指标；
+- 所有 async handler 共用单线程串行消费；
+- 对慢插件缺少隔离。
+
+### C. 插件注册方式偏硬编码
+
+当前主要通过 `RegisterBuiltinPlugins` 在代码中注册。这样虽然简单，但不利于：
+
+- 查看当前加载了哪些插件；
+- 做启停开关；
+- 做按环境配置；
+- 做插件级别调试。
+
+### D. 契约不清晰
+
+目前虽然已经有 `ASROutputData` / `LLMInputData` / `LLMOutputData` / `TTSInputData` / `MetricData`，但仍缺少以下约束：
+
+- 哪些字段允许修改；
+- 哪些字段不允许置空；
+- `stop` 的业务语义是什么；
+- `Err` 是否允许覆盖；
+- 插件最大允许耗时是多少。
+
+---
+
+## 4. V2 定位与设计原则
+
+## 4.1 架构定位
+
+V2 建议将系统正式命名为：
+
+> **Chat Interceptor & Observer Framework**
+
+而不是直接叫：
+
+> Plugin Platform
+
+这样命名更贴近当前阶段的真实能力，也更有利于控制团队预期。
+
+## 4.2 设计原则
+
+V2 应遵循以下原则：
+
+1. **保持业务主链路稳定**
+   - 不大规模改 ASR / LLM / TTS 现有逻辑；
+   - 优先在 Hook Runtime 和 Domain Facade 层增强。
+
+2. **先做治理，再做平台化**
+   - 先解决语义、边界、监控、稳定性；
+   - 再考虑更复杂的插件生态。
+
+3. **先区分 Interceptor 与 Observer**
+   - 所有可改写主流程的行为必须显式归类为 Interceptor；
+   - 所有只读观测行为必须显式归类为 Observer。
+
+4. **先明确契约，再扩展插件数量**
+   - 没有契约时，插件越多，维护成本越高。
+
+5. **增量演进，不做一次性重写**
+   - 能兼容现有 emit 接口的设计优先；
+   - 迁移要分阶段推进。
+
+---
+
+## 5. V2 总体架构
+
+## 5.1 三层结构
+
+V2 延续当前三层结构，但强化职责边界。
+
+### 第一层：业务主链路层
+
+职责：
+
+- 在 ASR / LLM / TTS / Session Metric 的关键节点 emit；
+- 不直接感知插件注册、调度策略、生命周期。
+
+不负责：
+
+- 插件注册；
+- 插件执行治理；
+- 插件元数据管理。
+
+### 第二层：Chat Domain Hook 层
+
+职责：
+
+- 定义 chat 领域事件、typed payload、领域 context；
+- 对业务代码暴露统一而稳定的入口；
+- 约束字段契约与 stop/error 语义。
+
+### 第三层：Generic Runtime 层
+
+职责：
+
+- 插件注册；
+- 排序与执行；
+- async 调度；
+- timeout / drop / metrics；
+- 生命周期管理。
+
+## 5.2 请求路径中的 Hook 角色
+
+```text
+ASR final text
+  -> ASR Output Interceptors
+  -> LLM Input Interceptors
+  -> LLM 执行
+  -> LLM Output Interceptors
+  -> TTS Input Interceptors
+  -> TTS Output Observers
+
+同时：
+  Metric Observers 在 turn_start / asr_first / asr_final / llm_start /
+  llm_first / llm_end / tts_start / tts_first / tts_stop 等阶段观测
+```
+
+这个拆法的核心是：
+
+- 业务主链路只关心“何时 emit”；
+- Interceptor 负责改写；
+- Observer 负责观测；
+- Runtime 负责治理。
+
+---
+
+## 6. 事件模型设计
+
+## 6.1 事件分层
+
+### A. Interceptor 类事件
+
+用于同步改写与流程控制。
+
+建议保留：
+
+- `chat.asr.output`
+- `chat.llm.input`
+- `chat.llm.output`
+- `chat.tts.input`
+
+这类事件应具备：
+
+- 按 priority 有序执行；
+- 可修改 payload；
+- 可 `stop`；
+- 可返回 error；
+- 必须快速返回。
+
+### B. Observer 类事件
+
+用于观测、埋点、日志、trace、审计等。
+
+建议归类为 Observer：
+
+- `chat.metric`
+- `chat.tts.output.start`
+- `chat.tts.output.stop`
+- 后续扩展的 audit / trace / debug event
+
+这类事件应具备：
+
+- 默认只读；
+- 不允许 stop 主流程；
+- 不参与主流程 payload 变更；
+- 可以异步执行；
+- 错误只影响观测链路。
+
+## 6.2 事件命名建议
+
+继续沿用现有分层命名即可，不建议马上大改命名体系。推荐保持：
+
+- `chat.asr.output`
+- `chat.llm.input`
+- `chat.llm.output`
+- `chat.tts.input`
+- `chat.tts.output.start`
+- `chat.tts.output.stop`
+- `chat.metric`
+
+原因：
+
+- 当前命名已经直观；
+- 与现有实现兼容；
+- 迁移成本最低。
+
+---
+
+## 7. 运行时设计
+
+## 7.1 PluginMeta
+
+V2 引入统一元数据，便于展示、启停、诊断和排序。
+
+```go
+package hooks
+
+type PluginKind string
+
+const (
+    PluginKindInterceptor PluginKind = "interceptor"
+    PluginKindObserver    PluginKind = "observer"
+)
+
+type PluginMeta struct {
+    Name        string
+    Version     string
+    Description string
+    Priority    int
+    Enabled     bool
+    Kind        PluginKind
+    Stage       string
+}
+```
+
+### 设计说明
+
+- `Name`：全局唯一标识；
+- `Version`：便于后续兼容与灰度；
+- `Priority`：排序依据；
+- `Enabled`：运行期开关；
+- `Kind`：区分 interceptor / observer；
+- `Stage`：声明所挂载的阶段。
+
+## 7.2 Registry
+
+V2 推荐引入显式注册中心，而不是让 Runtime 自己决定“有哪些插件”。
+
+```go
+package hooks
+
+type Registration struct {
+    Meta     PluginMeta
+    Register func(*Hub)
+}
+
+type Registry interface {
+    Add(reg Registration)
+    List() []Registration
+}
+```
+
+### Registry 负责什么
+
+- 保存插件定义；
+- 暴露可枚举的注册清单；
+- 支持按配置过滤是否启用；
+- 为调试和观测提供基础数据。
+
+### Registry 不负责什么
+
+- 不直接执行插件；
+- 不直接承载业务状态；
+- 不替代 Runtime 的执行逻辑。
+
+## 7.3 Lifecycle
+
+为带状态插件提供最小生命周期。
+
+```go
+package hooks
+
+type Lifecycle interface {
+    Init(context.Context) error
+    Close() error
+}
+```
+
+建议：
+
+- 无状态插件可不实现；
+- 有缓存、后台任务、连接池的插件实现该接口；
+- Runtime 统一管理调用时机。
+
+## 7.4 Interceptor 接口
+
+```go
+package hooks
+
+type Interceptor[T any] interface {
+    Meta() PluginMeta
+    Handle(Context, T) (T, bool, error)
+}
+```
+
+设计意图：
+
+- 保留“改写 + stop + error”三种能力；
+- 利用泛型提升编译期约束；
+- 降低 `any` 造成的误用风险。
+
+## 7.5 Observer 接口
+
+```go
+package hooks
+
+type Observer[T any] interface {
+    Meta() PluginMeta
+    Handle(Context, T)
+}
+```
+
+设计意图：
+
+- 明确“只观察，不改写”；
+- 从语义上消除对 `stop` 的误用；
+- 方便后续对 observer 做独立调度策略。
+
+## 7.6 Async Runtime
+
+### 当前问题
+
+当前 async 执行模型最大的问题不是“不能工作”，而是“缺少边界”。
+
+### V2 设计目标
+
+为 async observer 增加以下能力：
+
+- bounded queue；
+- timeout；
+- dropped 统计；
+- per-plugin 执行指标；
+- 后续可扩展为多队列 / 多 worker。
+
+### 建议配置
+
+```go
+package hooks
+
+type AsyncConfig struct {
+    QueueSize    int
+    WorkerCount  int
+    DropWhenFull bool
+    Timeout      time.Duration
+}
+```
+
+### 推荐默认值
+
+- `QueueSize = 1024`
+- `WorkerCount = 1`
+- `DropWhenFull = true`
+- `Timeout = 200ms`
+
+### 推荐策略
+
+1. 默认先保持单 worker，保证顺序语义；
+2. 队列满时优先丢弃 observer 事件，而不是拖慢主链路；
+3. 记录 dropped count 和 timeout count；
+4. 若未来出现高负载 observer，再按事件或插件拆分队列。
+
+---
+
+## 8. 领域契约
+
+V2 必须把 payload 契约显式写清楚。
+
+## 8.1 ASROutputData
+
+用途：ASR 最终文本与说话人结果改写。
+
+| 字段 | 是否可改 | 说明 |
+| --- | --- | --- |
+| `Text` | 是 | 可做清洗、归一化、过滤 |
+| `SpeakerResult` | 是 | 可做说话人修正或增强 |
+
+约束：
+
+- 插件不得长时间阻塞；
+- `stop=true` 表示本轮文本不再继续进入 LLM；
+- 若返回空文本，应明确由插件自行承担后果。
+
+## 8.2 LLMInputData
+
+用途：在发起 LLM 请求前，对消息与工具做改写。
+
+| 字段 | 是否可改 | 说明 |
+| --- | --- | --- |
+| `UserMessage` | 是 | 不允许置空 |
+| `RequestMessages` | 是 | 可裁剪、重排、注入 system prompt |
+| `Tools` | 是 | 可做过滤或附加 |
+
+约束：
+
+- `UserMessage` 不允许为 `nil`；
+- 插件必须保证输出仍满足下游 LLM Provider 的最小输入要求；
+- `stop=true` 表示本次 LLM 请求被拦截终止。
+
+## 8.3 LLMOutputData
+
+用途：在 LLM 输出完成后，改写展示文本或补充错误语义。
+
+| 字段 | 是否可改 | 说明 |
+| --- | --- | --- |
+| `FullText` | 是 | 可做安全改写、格式整理、语音友好化 |
+| `Err` | 谨慎 | 建议附加上下文，不建议直接吞掉底层错误 |
+
+约束：
+
+- 不建议插件无痕覆盖底层真实错误；
+- `stop=true` 表示后续不再继续进入 TTS 或消息更新；
+- 未来可将 `Err` 拆成 `OriginErr` / `DisplayErr`。
+
+## 8.4 TTSInputData
+
+用途：在文本进入 TTS 前做可朗读化处理。
+
+| 字段 | 是否可改 | 说明 |
+| --- | --- | --- |
+| `Text` | 是 | 可做数值、标点、emoji 可朗读化 |
+| `IsStart` | 默认否 | 视为协议边界字段 |
+| `IsEnd` | 默认否 | 视为协议边界字段 |
+
+约束：
+
+- 普通插件建议只改 `Text`；
+- `IsStart` / `IsEnd` 应保留给更高权限或专用插件；
+- `stop=true` 表示当前片段不进入 TTS。
+
+## 8.5 MetricData
+
+用途：链路观测。
+
+| 字段 | 是否可改 | 说明 |
+| --- | --- | --- |
+| `Stage` | 否 | 只读 |
+| `Ts` | 否 | 只读 |
+| `Err` | 否 | 只读，仅用于观测 |
+
+约束：
+
+- 不允许 stop 主流程；
+- 不允许改写后再反馈给主链路；
+- 仅用于日志、指标、追踪、调试。
+
+---
+
+## 9. 配置模型
+
+推荐为 Hook 系统增加最小配置模型：
+
+```yaml
+chat_hooks:
+  enabled: true
+  async:
+    queue_size: 1024
+    worker_count: 1
+    drop_when_full: true
+    timeout_ms: 200
+  plugins:
+    statistic_plugin:
+      enabled: true
+      priority: 100
+```
+
+配置设计目标：
+
+- 支持插件启停；
+- 支持 priority 覆盖；
+- 支持 async 运行参数控制；
+- 为未来插件级 config schema 预留空间。
+
+---
+
+## 10. 可观测性要求
+
+Runtime 至少应采集以下指标：
+
+- plugin 调用次数；
+- plugin 耗时；
+- error 次数；
+- stop 次数（interceptor）；
+- dropped 次数（observer async）；
+- timeout 次数；
+- 当前 async queue 长度。
+
+建议日志/指标中包含：
+
+- `plugin_name`
+- `plugin_kind`
+- `stage`
+- `priority`
+- `duration_ms`
+- `result`
+
+如果后续接 tracing，可进一步记录：
+
+- session_id
+- device_id
+- turn_id
+- correlation_id
+
+---
+
+## 11. 迁移计划
+
+## 11.1 阶段 1：Runtime 增强（P0）
+
+目标：在不改业务接入点的前提下提升稳定性。
+
+工作项：
+
+- 为 async observer 增加 bounded queue；
+- 增加 timeout 与 dropped 统计；
+- 增加 Runtime 基础指标；
+- 保持现有 `Emit` / `RegisterSync` / `RegisterAsync` 接口兼容。
+
+产出：
+
+- 稳定性提升；
+- 为后续 observer 扩展提供边界。
+
+## 11.2 阶段 2：语义分层（P0）
+
+目标：显式区分 Interceptor 与 Observer。
+
+工作项：
+
+- 在 Domain Hook 层新增清晰 façade；
+- 将 `Metric` 事件转为标准 observer 语义；
+- 明确不允许 stop 的事件集合。
+
+产出：
+
+- 语义更清晰；
+- 插件作者更不容易误用。
+
+## 11.3 阶段 3：Registry + Meta（P1）
+
+目标：将“有哪些插件”从硬编码逻辑中抽离。
+
+工作项：
+
+- 引入 `PluginMeta`；
+- 引入 `Registration` / `Registry`；
+- 支持按配置启停插件；
+- 支持列出当前已加载插件。
+
+产出：
+
+- 注册透明；
+- 便于调试、观测和配置治理。
+
+## 11.4 阶段 4：契约与生命周期（P1）
+
+目标：让插件边界正式化。
+
+工作项：
+
+- 固化 payload 契约；
+- 引入 `Lifecycle`；
+- 为有状态插件增加初始化与关闭流程。
+
+产出：
+
+- 更适合承载复杂内建插件；
+- 便于演进到更完整的插件体系。
+
+## 11.5 阶段 5：高级能力（P2）
+
+目标：支撑更复杂插件生态。
+
+工作项：
+
+- 按事件拆分队列；
+- 多 worker observer runtime；
+- tracing / metrics 深度集成；
+- 针对重插件的隔离执行策略。
+
+---
+
+## 12. 非目标
+
+V2 当前**不追求**：
+
+- 第三方不受信插件沙箱；
+- 进程外 RPC 插件体系；
+- 热加载复杂插件生态；
+- 完整插件市场。
+
+这些能力应在未来更高版本评估，不应提前引入复杂度。
+
+---
+
+## 13. 落地建议
+
+如果只允许当前迭代做 3 件事，推荐顺序如下：
+
+1. **先做 Async Runtime 治理**
+   - 这是稳定性收益最高的一步。
+
+2. **再做 Interceptor / Observer 语义拆分**
+   - 这是降低误用风险最有效的一步。
+
+3. **补齐契约与 Meta/Registry**
+   - 这是把系统从“能用”推进到“可管理”的关键一步。
+
+---
+
+## 14. 总结
+
+V2 的目标不是把当前 Hook 体系包装成一个听起来更大的“Plugin Platform”，而是把它演进成一个真正：
+
+- 语义清晰；
+- 执行可控；
+- 可观测；
+- 可渐进扩展；
+- 与当前聊天主链路兼容的扩展框架。
+
+因此，V2 最重要的不是“增加更多插件”，而是先完成以下三件事：
+
+- 把 **Interceptor** 与 **Observer** 分清；
+- 把 **async runtime 边界** 补齐；
+- 把 **payload 契约与插件元数据** 建立起来。
+
+完成这三步后，当前仓库的 Hook 体系才算真正具备长期演进的基础。

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,6 +15,18 @@ chat:
   chat_max_silence_duration: 400   # 句子结束静音阈值（毫秒），默认 400
   realtime_mode: 4 # 1: vad打断模式 2: asr打断模式 3: asr时识别到声纹时进行打断 4. asr出结果打断(兼容流式或离线)
 
+chat_hooks:
+  enabled: true
+  async:
+    queue_size: 1024
+    worker_count: 1
+    drop_when_full: false
+    timeout_ms: 200
+  plugins:
+    statistic_plugin:
+      enabled: true
+      priority: 100
+
 config_provider:          #对应domain/config/中的provider
   type: "manager"         #现在可以是 manager, redis
   enable_periodic_update: true  #是否启用周期性配置更新

--- a/internal/app/server/chat/chat.go
+++ b/internal/app/server/chat/chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -15,6 +16,7 @@ import (
 	userconfig "xiaozhi-esp32-server-golang/internal/domain/config"
 	"xiaozhi-esp32-server-golang/internal/domain/eventbus"
 	"xiaozhi-esp32-server-golang/internal/domain/openclaw"
+	pkghooks "xiaozhi-esp32-server-golang/internal/pkg/hooks"
 	log "xiaozhi-esp32-server-golang/logger"
 )
 
@@ -33,6 +35,55 @@ type ChatManager struct {
 }
 
 type ChatManagerOption func(*ChatManager)
+
+var (
+	chatHookAsyncExecutorOnce sync.Once
+	chatHookAsyncExecutor     *pkghooks.AsyncExecutor
+)
+
+func sharedChatHookAsyncExecutor() *pkghooks.AsyncExecutor {
+	chatHookAsyncExecutorOnce.Do(func() {
+		asyncCfg := pkghooks.AsyncConfig{
+			QueueSize:    viper.GetInt("chat_hooks.async.queue_size"),
+			WorkerCount:  viper.GetInt("chat_hooks.async.worker_count"),
+			DropWhenFull: viper.GetBool("chat_hooks.async.drop_when_full"),
+			Timeout:      time.Duration(viper.GetInt("chat_hooks.async.timeout_ms")) * time.Millisecond,
+		}
+		chatHookAsyncExecutor = pkghooks.NewAsyncExecutor(context.Background(), asyncCfg)
+		log.Infof("初始化全局共享 chat hook observer executor: queue_size=%d worker_count=%d drop_when_full=%v timeout=%s", asyncCfg.QueueSize, asyncCfg.WorkerCount, asyncCfg.DropWhenFull, asyncCfg.Timeout)
+	})
+	return chatHookAsyncExecutor
+}
+
+func newChatHookHub(parent context.Context) *chathooks.Hub {
+	asyncCfg := pkghooks.AsyncConfig{
+		QueueSize:    viper.GetInt("chat_hooks.async.queue_size"),
+		WorkerCount:  viper.GetInt("chat_hooks.async.worker_count"),
+		DropWhenFull: viper.GetBool("chat_hooks.async.drop_when_full"),
+		Timeout:      time.Duration(viper.GetInt("chat_hooks.async.timeout_ms")) * time.Millisecond,
+	}
+	hub := chathooks.NewHub(parent, pkghooks.WithAsyncConfig(asyncCfg), pkghooks.WithAsyncExecutor(sharedChatHookAsyncExecutor()))
+	stats := hub.Stats()
+	log.Infof("初始化 chat hook hub: queue_size=%d worker_count=%d drop_when_full=%v timeout=%s dropped_async=%d", asyncCfg.QueueSize, asyncCfg.WorkerCount, asyncCfg.DropWhenFull, asyncCfg.Timeout, stats.DroppedAsync)
+	return hub
+}
+
+func chatHookBuiltinOverrides() map[string]chathooks.BuiltinPluginConfig {
+	overrides := map[string]chathooks.BuiltinPluginConfig{}
+	for _, reg := range chathooks.BuiltinRegistrations() {
+		path := "chat_hooks.plugins." + reg.Meta.Name
+		cfg := chathooks.BuiltinPluginConfig{}
+		if viper.IsSet(path + ".enabled") {
+			enabled := viper.GetBool(path + ".enabled")
+			cfg.Enabled = &enabled
+		}
+		if viper.IsSet(path + ".priority") {
+			cfg.Priority = viper.GetInt(path + ".priority")
+		}
+		overrides[reg.Meta.Name] = cfg
+	}
+	return overrides
+}
 
 func NewChatManager(deviceID string, transport types_conn.IConn, options ...ChatManagerOption) (*ChatManager, error) {
 
@@ -62,8 +113,15 @@ func NewChatManager(deviceID string, transport types_conn.IConn, options ...Chat
 	cm.transport.OnClose(cm.OnClose)
 
 	serverTransport := NewServerTransport(cm.transport, clientState)
-	hookHub := chathooks.NewHub(cm.ctx)
-	chathooks.RegisterBuiltinPlugins(hookHub)
+	hookHub := newChatHookHub(cm.ctx)
+	if !viper.IsSet("chat_hooks.enabled") || viper.GetBool("chat_hooks.enabled") {
+		if err := chathooks.RegisterBuiltinPlugins(hookHub, chatHookBuiltinOverrides()); err != nil {
+			log.Errorf("注册 chat hook builtin plugins 失败: %v", err)
+			cm.transport.Close()
+			return nil, err
+		}
+		log.Infof("已加载 chat hook plugins: %+v", hookHub.PluginMetas())
+	}
 
 	cm.session = NewChatSession(
 		clientState,

--- a/internal/app/server/chat/session.go
+++ b/internal/app/server/chat/session.go
@@ -1543,10 +1543,7 @@ func (s *ChatSession) emitMetricStage(ctx context.Context, stage chathooks.Metri
 		return
 	}
 
-	stop, hookErr := s.hookHub.EmitMetric(s.hookContext(ctx), chathooks.MetricData{Stage: stage, Ts: ts, Err: err})
-	if stop {
-		log.Debugf("METRIC hook returned stop (ignored): stage=%s", stage)
-	}
+	hookErr := s.hookHub.EmitMetric(s.hookContext(ctx), chathooks.MetricData{Stage: stage, Ts: ts, Err: err})
 	if hookErr != nil {
 		log.Warnf("METRIC hook 执行失败: stage=%s err=%v", stage, hookErr)
 	}

--- a/internal/app/server/chat/tts.go
+++ b/internal/app/server/chat/tts.go
@@ -242,14 +242,9 @@ func (t *TTSManager) runSenderLoop(ctx context.Context) {
 				}
 			case AudioQueueKindTtsStart:
 				if t.session != nil {
-					stop, hookErr := t.session.hookHub.EmitTTSOutputStart(t.session.hookContext(ctx))
+					hookErr := t.session.hookHub.EmitTTSOutputStart(t.session.hookContext(ctx))
 					if hookErr != nil {
 						log.Warnf("TTS_OUTPUT_START hook 执行失败: %v", hookErr)
-					}
-					if stop {
-						log.Infof("TTS_OUTPUT_START hook 请求停止当前流程")
-						t.InterruptAndClearQueue()
-						continue
 					}
 				}
 				t.clientState.SetStartTtsTs()
@@ -299,7 +294,7 @@ func (t *TTSManager) runSenderLoop(ctx context.Context) {
 					t.session.TraceTtsStop(ctx, t.clientState.Statistic.TtsStopTs, stopErr)
 				}
 				if t.session != nil {
-					_, hookErr := t.session.hookHub.EmitTTSOutputStop(t.session.hookContext(ctx), chathooks.TTSOutputStopData{Err: stopErr})
+					hookErr := t.session.hookHub.EmitTTSOutputStop(t.session.hookContext(ctx), chathooks.TTSOutputStopData{Err: stopErr})
 					if hookErr != nil {
 						log.Warnf("TTS_OUTPUT_STOP hook 执行失败: %v", hookErr)
 					}

--- a/internal/domain/chat/hooks/hub.go
+++ b/internal/domain/chat/hooks/hub.go
@@ -2,19 +2,22 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	pkghooks "xiaozhi-esp32-server-golang/internal/pkg/hooks"
+	log "xiaozhi-esp32-server-golang/logger"
 )
 
 type SyncHandler func(Context, any) (any, bool, error)
 type AsyncHandler func(Context, any)
 
 type Hub struct {
-	hub *pkghooks.Hub
+	hub        *pkghooks.Hub
+	lifecycles []Lifecycle
 }
 
-func NewHub(parent context.Context) *Hub {
-	return &Hub{hub: pkghooks.NewHub(parent)}
+func NewHub(parent context.Context, opts ...pkghooks.HubOption) *Hub {
+	return &Hub{hub: pkghooks.NewHub(parent, opts...)}
 }
 
 func (h *Hub) Close() {
@@ -22,6 +25,36 @@ func (h *Hub) Close() {
 		return
 	}
 	h.hub.Close()
+	for i := len(h.lifecycles) - 1; i >= 0; i-- {
+		if err := h.lifecycles[i].Close(); err != nil {
+			log.Warnf("hook lifecycle close failed: %v", err)
+		}
+	}
+}
+
+func (h *Hub) InitLifecycle(ctx context.Context, lc Lifecycle) error {
+	if h == nil || lc == nil {
+		return nil
+	}
+	if err := lc.Init(ctx); err != nil {
+		return err
+	}
+	h.lifecycles = append(h.lifecycles, lc)
+	return nil
+}
+
+func (h *Hub) Stats() pkghooks.Stats {
+	if h == nil || h.hub == nil {
+		return pkghooks.Stats{}
+	}
+	return h.hub.Stats()
+}
+
+func (h *Hub) PluginMetas() []pkghooks.PluginMeta {
+	if h == nil || h.hub == nil {
+		return nil
+	}
+	return h.hub.PluginMetas()
 }
 
 func (h *Hub) Emit(event string, ctx Context, payload any) (any, bool, error) {
@@ -59,38 +92,95 @@ func (h *Hub) EmitTTSInput(ctx Context, data TTSInputData) (TTSInputData, bool, 
 	return EmitTyped(h, EventChatTTSInput, ctx, data)
 }
 
-func (h *Hub) EmitTTSOutputStart(ctx Context) (bool, error) {
-	_, stop, err := EmitTyped(h, EventChatTTSOutputStart, ctx, TTSOutputStartData{})
-	return stop, err
+func (h *Hub) EmitTTSOutputStart(ctx Context) error {
+	_, _, err := h.Emit(EventChatTTSOutputStart, ctx, TTSOutputStartData{})
+	return err
 }
 
-func (h *Hub) EmitTTSOutputStop(ctx Context, data TTSOutputStopData) (bool, error) {
-	_, stop, err := EmitTyped(h, EventChatTTSOutputStop, ctx, data)
-	return stop, err
+func (h *Hub) EmitTTSOutputStop(ctx Context, data TTSOutputStopData) error {
+	_, _, err := h.Emit(EventChatTTSOutputStop, ctx, data)
+	return err
 }
 
-func (h *Hub) EmitMetric(ctx Context, data MetricData) (bool, error) {
-	_, stop, err := EmitTyped(h, EventChatMetric, ctx, data)
-	return stop, err
+func (h *Hub) EmitMetric(ctx Context, data MetricData) error {
+	_, _, err := h.Emit(EventChatMetric, ctx, data)
+	return err
 }
 
 func (h *Hub) RegisterSync(event, name string, priority int, handler SyncHandler) {
-	h.hub.RegisterSync(event, name, priority, func(ctx pkghooks.Context, payload any) (any, bool, error) {
+	if err := h.RegisterInterceptor(event, PluginMeta{Name: name, Priority: priority}, handler); err != nil {
+		panic(err)
+	}
+}
+
+func (h *Hub) RegisterInterceptor(event string, meta PluginMeta, handler SyncHandler) error {
+	if h == nil || h.hub == nil {
+		return nil
+	}
+	if err := ValidateEventKind(event, PluginKindInterceptor); err != nil {
+		return err
+	}
+	h.hub.RegisterSyncMeta(event, toPkgMeta(meta, pkghooks.PluginKindInterceptor, event), func(ctx pkghooks.Context, payload any) (any, bool, error) {
 		return handler(fromPkgContext(ctx), payload)
 	})
+	return nil
 }
 
 func (h *Hub) RegisterAsync(event, name string, priority int, handler AsyncHandler) {
-	h.hub.RegisterAsync(event, name, priority, func(ctx pkghooks.Context, payload any) {
+	if err := h.RegisterObserver(event, PluginMeta{Name: name, Priority: priority}, handler); err != nil {
+		panic(err)
+	}
+}
+
+func (h *Hub) RegisterObserver(event string, meta PluginMeta, handler AsyncHandler) error {
+	if h == nil || h.hub == nil {
+		return nil
+	}
+	if err := ValidateEventKind(event, PluginKindObserver); err != nil {
+		return err
+	}
+	h.hub.RegisterAsyncMeta(event, toPkgMeta(meta, pkghooks.PluginKindObserver, event), func(ctx pkghooks.Context, payload any) {
 		handler(fromPkgContext(ctx), payload)
 	})
+	return nil
+}
+
+func RegisterBuiltinPlugins(hub *Hub, overrides map[string]BuiltinPluginConfig) error {
+	if hub == nil {
+		return nil
+	}
+	for _, reg := range BuiltinRegistrations() {
+		if override, ok := overrides[reg.Meta.Name]; ok {
+			if override.Enabled != nil {
+				reg.Meta.Enabled = *override.Enabled
+			}
+			if override.Priority != 0 {
+				reg.Meta.Priority = override.Priority
+			}
+		}
+		if !reg.Meta.Enabled {
+			continue
+		}
+		if reg.Lifecycle != nil {
+			if err := hub.InitLifecycle(context.Background(), reg.Lifecycle); err != nil {
+				return fmt.Errorf("init lifecycle for %s: %w", reg.Meta.Name, err)
+			}
+		}
+		if reg.Register != nil {
+			if err := reg.Register(hub, reg.Meta); err != nil {
+				return fmt.Errorf("register builtin plugin %s: %w", reg.Meta.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func toPkgMeta(meta PluginMeta, kind pkghooks.PluginKind, event string) pkghooks.PluginMeta {
+	return pkghooks.PluginMeta{Name: meta.Name, Priority: meta.Priority, Kind: kind, Stage: event}
 }
 
 func toPlatformContext(ctx Context) pkghooks.Context {
-	return pkghooks.Context{
-		Ctx:  ctx.Ctx,
-		Meta: ctx,
-	}
+	return pkghooks.Context{Ctx: ctx.Ctx, Meta: ctx}
 }
 
 func fromPkgContext(ctx pkghooks.Context) Context {

--- a/internal/domain/chat/hooks/statistic_plugin.go
+++ b/internal/domain/chat/hooks/statistic_plugin.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"context"
 	"time"
 
 	cmap "github.com/orcaman/concurrent-map/v2"
@@ -22,28 +23,44 @@ type turnMetric struct {
 }
 
 type statisticPlugin struct {
-	// 使用 concurrent-map 替代 sync.Map，性能更好
 	currentTurn cmap.ConcurrentMap[string, int64]
 	turns       cmap.ConcurrentMap[string, *turnMetric]
 	lastSeen    cmap.ConcurrentMap[string, int64]
 
-	// 计数器，用于控制清理频率
 	cleanupCounter   int64
-	cleanupThreshold int64 // 每 N 次调用执行一次全量清理
+	cleanupThreshold int64
 }
 
-func RegisterBuiltinPlugins(hub *Hub) {
-	if hub == nil {
-		return
-	}
-
-	plugin := &statisticPlugin{
+func newStatisticPlugin() *statisticPlugin {
+	return &statisticPlugin{
 		currentTurn:      cmap.New[int64](),
 		turns:            cmap.New[*turnMetric](),
 		lastSeen:         cmap.New[int64](),
-		cleanupThreshold: 100, // 每 100 次调用执行一次清理
+		cleanupThreshold: 100,
 	}
-	hub.RegisterAsync(EventChatMetric, "statistic_plugin", 100, plugin.onMetric)
+}
+
+func (p *statisticPlugin) Init(context.Context) error { return nil }
+func (p *statisticPlugin) Close() error               { return nil }
+
+func BuiltinRegistrations() []Registration {
+	plugin := newStatisticPlugin()
+	meta := PluginMeta{
+		Name:        "statistic_plugin",
+		Version:     "v1",
+		Description: "Aggregate turn metrics and log a summary on TTS stop",
+		Priority:    100,
+		Enabled:     true,
+		Kind:        PluginKindObserver,
+		Stage:       EventChatMetric,
+	}
+	return []Registration{{
+		Meta:      meta,
+		Lifecycle: plugin,
+		Register: func(hub *Hub, meta PluginMeta) error {
+			return hub.RegisterObserver(EventChatMetric, meta, plugin.onMetric)
+		},
+	}}
 }
 
 func (p *statisticPlugin) onMetric(ctx Context, payload any) {
@@ -54,8 +71,6 @@ func (p *statisticPlugin) onMetric(ctx Context, payload any) {
 
 	nowTs := time.Now().UnixMilli()
 	p.lastSeen.Set(ctx.SessionID, nowTs)
-
-	// 减少清理频率：每 N 次调用才执行一次全量清理
 	if p.cleanupCounter++; p.cleanupCounter%p.cleanupThreshold == 0 {
 		p.cleanupStale(nowTs)
 	}
@@ -87,7 +102,6 @@ func (p *statisticPlugin) onMetric(ctx Context, payload any) {
 
 func (p *statisticPlugin) getOrCreateTurn(sessionID string, stage MetricStage) *turnMetric {
 	if stage == MetricTurnStart {
-		// currentTurn + 1
 		var newTurnID int64 = 1
 		if val, ok := p.currentTurn.Get(sessionID); ok {
 			newTurnID = val + 1
@@ -98,20 +112,15 @@ func (p *statisticPlugin) getOrCreateTurn(sessionID string, stage MetricStage) *
 		p.turns.Set(sessionID, tm)
 		return tm
 	}
-
-	// 尝试获取 existing turn
 	if val, ok := p.turns.Get(sessionID); ok {
 		return val
 	}
-
-	// 获取或创建 currentTurn
 	var turnID int64 = 1
 	if val, ok := p.currentTurn.Get(sessionID); ok {
 		turnID = val
 	} else {
 		p.currentTurn.Set(sessionID, turnID)
 	}
-
 	tm := &turnMetric{turnID: turnID}
 	p.turns.Set(sessionID, tm)
 	return tm
@@ -142,15 +151,12 @@ func (p *statisticPlugin) logTurnMetric(sessionID string, tm *turnMetric) {
 
 func (p *statisticPlugin) cleanupStale(nowTs int64) {
 	const ttl = int64(2 * 60 * 1000)
-
-	// 遍历 lastSeen，清理过期项
 	keysToDelete := make([]string, 0)
 	p.lastSeen.IterCb(func(key string, value int64) {
 		if nowTs-value > ttl {
 			keysToDelete = append(keysToDelete, key)
 		}
 	})
-
 	for _, key := range keysToDelete {
 		p.lastSeen.Remove(key)
 		p.turns.Remove(key)

--- a/internal/domain/chat/hooks/types.go
+++ b/internal/domain/chat/hooks/types.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cloudwego/eino/schema"
 	"xiaozhi-esp32-server-golang/internal/domain/speaker"
@@ -13,6 +14,73 @@ type Context struct {
 	DeviceID  string
 }
 
+type PluginKind string
+
+type EventKind string
+
+const (
+	PluginKindInterceptor PluginKind = "interceptor"
+	PluginKindObserver    PluginKind = "observer"
+)
+
+const (
+	EventKindInterceptor EventKind = "interceptor"
+	EventKindObserver    EventKind = "observer"
+)
+
+type PluginMeta struct {
+	Name        string
+	Version     string
+	Description string
+	Priority    int
+	Enabled     bool
+	Kind        PluginKind
+	Stage       string
+}
+
+type Lifecycle interface {
+	Init(context.Context) error
+	Close() error
+}
+
+type Registration struct {
+	Meta      PluginMeta
+	Register  func(*Hub, PluginMeta) error
+	Lifecycle Lifecycle
+}
+
+type Registry interface {
+	Add(Registration)
+	List() []Registration
+}
+
+type InMemoryRegistry struct {
+	regs []Registration
+}
+
+func NewRegistry() *InMemoryRegistry { return &InMemoryRegistry{} }
+
+func (r *InMemoryRegistry) Add(reg Registration) {
+	if r == nil {
+		return
+	}
+	r.regs = append(r.regs, reg)
+}
+
+func (r *InMemoryRegistry) List() []Registration {
+	if r == nil {
+		return nil
+	}
+	out := make([]Registration, len(r.regs))
+	copy(out, r.regs)
+	return out
+}
+
+type BuiltinPluginConfig struct {
+	Enabled  *bool
+	Priority int
+}
+
 const (
 	EventChatASROutput      = "chat.asr.output"
 	EventChatLLMInput       = "chat.llm.input"
@@ -22,6 +90,27 @@ const (
 	EventChatTTSOutputStop  = "chat.tts.output.stop"
 	EventChatMetric         = "chat.metric"
 )
+
+var eventKinds = map[string]EventKind{
+	EventChatASROutput:      EventKindInterceptor,
+	EventChatLLMInput:       EventKindInterceptor,
+	EventChatLLMOutput:      EventKindInterceptor,
+	EventChatTTSInput:       EventKindInterceptor,
+	EventChatTTSOutputStart: EventKindObserver,
+	EventChatTTSOutputStop:  EventKindObserver,
+	EventChatMetric:         EventKindObserver,
+}
+
+func ValidateEventKind(event string, kind PluginKind) error {
+	expected, ok := eventKinds[event]
+	if !ok {
+		return fmt.Errorf("unknown hook event: %s", event)
+	}
+	if PluginKind(expected) != kind {
+		return fmt.Errorf("hook event %s requires %s registration, got %s", event, expected, kind)
+	}
+	return nil
+}
 
 type ASROutputData struct {
 	Text          string

--- a/internal/pkg/hooks/hub.go
+++ b/internal/pkg/hooks/hub.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 type Context struct {
@@ -15,16 +17,146 @@ type Context struct {
 type SyncHandler func(Context, any) (any, bool, error)
 type AsyncHandler func(Context, any)
 
+type PluginKind string
+
+const (
+	PluginKindInterceptor PluginKind = "interceptor"
+	PluginKindObserver    PluginKind = "observer"
+)
+
+type PluginMeta struct {
+	Name     string
+	Priority int
+	Kind     PluginKind
+	Stage    string
+}
+
+type AsyncConfig struct {
+	QueueSize    int
+	WorkerCount  int
+	DropWhenFull bool
+	Timeout      time.Duration
+}
+
+type HubOption func(*Hub)
+
 type namedSync struct {
-	name     string
-	priority int
-	handler  SyncHandler
+	meta    PluginMeta
+	handler SyncHandler
 }
 
 type namedAsync struct {
-	name     string
-	priority int
-	handler  AsyncHandler
+	meta    PluginMeta
+	handler AsyncHandler
+}
+
+type PluginStats struct {
+	Invocations     int64
+	Errors          int64
+	Stops           int64
+	Timeouts        int64
+	DroppedAsync    int64
+	TotalDurationMs int64
+}
+
+type Stats struct {
+	AsyncQueueLength int
+	DroppedAsync     int64
+	Plugins          map[string]PluginStats
+}
+
+type AsyncExecutor struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	cfg AsyncConfig
+
+	mu    sync.Mutex
+	cond  *sync.Cond
+	queue []func()
+
+	workerWG sync.WaitGroup
+}
+
+func NewAsyncExecutor(parent context.Context, cfg AsyncConfig) *AsyncExecutor {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = 1024
+	}
+	if cfg.WorkerCount <= 0 {
+		cfg.WorkerCount = 1
+	}
+	ctx, cancel := context.WithCancel(parent)
+	exec := &AsyncExecutor{ctx: ctx, cancel: cancel, cfg: cfg}
+	exec.cond = sync.NewCond(&exec.mu)
+	for i := 0; i < exec.cfg.WorkerCount; i++ {
+		exec.workerWG.Add(1)
+		go exec.run()
+	}
+	return exec
+}
+
+func (e *AsyncExecutor) run() {
+	defer e.workerWG.Done()
+	for {
+		task := e.pop()
+		if task == nil {
+			return
+		}
+		task()
+	}
+}
+
+func (e *AsyncExecutor) pop() func() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for len(e.queue) == 0 && e.ctx.Err() == nil {
+		e.cond.Wait()
+	}
+	if len(e.queue) == 0 {
+		return nil
+	}
+	task := e.queue[0]
+	e.queue[0] = nil
+	e.queue = e.queue[1:]
+	return task
+}
+
+func (e *AsyncExecutor) Submit(task func()) bool {
+	if e == nil || task == nil {
+		return true
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.ctx.Err() != nil {
+		return false
+	}
+	if e.cfg.DropWhenFull && e.cfg.QueueSize > 0 && len(e.queue) >= e.cfg.QueueSize {
+		return false
+	}
+	e.queue = append(e.queue, task)
+	e.cond.Signal()
+	return true
+}
+
+func (e *AsyncExecutor) QueueLength() int {
+	if e == nil {
+		return 0
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.queue)
+}
+
+func (e *AsyncExecutor) Close() {
+	if e == nil || e.cancel == nil {
+		return
+	}
+	e.cancel()
+	e.cond.Broadcast()
+	e.workerWG.Wait()
 }
 
 type Hub struct {
@@ -36,26 +168,67 @@ type Hub struct {
 	syncHandlers  map[string][]namedSync
 	asyncHandlers map[string][]namedAsync
 
-	asyncMu    sync.Mutex
-	asyncCond  *sync.Cond
-	asyncQueue []func()
+	asyncConfig AsyncConfig
+	asyncExec   *AsyncExecutor
+	ownsAsync   bool
+
+	droppedAsync atomic.Int64
+
+	statsMu      sync.Mutex
+	pluginStats  map[string]*PluginStats
+	pluginMetaMu sync.RWMutex
+	pluginMeta   map[string]PluginMeta
 }
 
-func NewHub(parent context.Context) *Hub {
+func defaultAsyncConfig() AsyncConfig {
+	return AsyncConfig{QueueSize: 1024, WorkerCount: 1, DropWhenFull: false, Timeout: 0}
+}
+
+func WithAsyncConfig(cfg AsyncConfig) HubOption {
+	return func(h *Hub) {
+		if cfg.QueueSize > 0 {
+			h.asyncConfig.QueueSize = cfg.QueueSize
+		}
+		if cfg.WorkerCount > 0 {
+			h.asyncConfig.WorkerCount = cfg.WorkerCount
+		}
+		if cfg.Timeout > 0 {
+			h.asyncConfig.Timeout = cfg.Timeout
+		}
+		h.asyncConfig.DropWhenFull = cfg.DropWhenFull
+	}
+}
+
+func WithAsyncExecutor(exec *AsyncExecutor) HubOption {
+	return func(h *Hub) {
+		h.asyncExec = exec
+		h.ownsAsync = false
+	}
+}
+
+func NewHub(parent context.Context, opts ...HubOption) *Hub {
 	if parent == nil {
 		parent = context.Background()
 	}
-
 	ctx, cancel := context.WithCancel(parent)
 	h := &Hub{
 		ctx:           ctx,
 		cancel:        cancel,
 		syncHandlers:  make(map[string][]namedSync),
 		asyncHandlers: make(map[string][]namedAsync),
+		asyncConfig:   defaultAsyncConfig(),
+		pluginStats:   make(map[string]*PluginStats),
+		pluginMeta:    make(map[string]PluginMeta),
 	}
-	h.asyncCond = sync.NewCond(&h.asyncMu)
-
-	go h.runAsync()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(h)
+		}
+	}
+	if h.asyncExec == nil {
+		h.asyncExec = NewAsyncExecutor(ctx, h.asyncConfig)
+		h.ownsAsync = true
+	}
 	return h
 }
 
@@ -64,88 +237,186 @@ func (h *Hub) Close() {
 		return
 	}
 	h.cancel()
-	h.asyncCond.Broadcast()
-}
-
-func (h *Hub) runAsync() {
-	for {
-		task := h.popAsync()
-		if task == nil {
-			return
-		}
-		task()
+	if h.ownsAsync && h.asyncExec != nil {
+		h.asyncExec.Close()
 	}
 }
 
-func (h *Hub) popAsync() func() {
-	h.asyncMu.Lock()
-	defer h.asyncMu.Unlock()
-
-	for len(h.asyncQueue) == 0 && h.ctx.Err() == nil {
-		h.asyncCond.Wait()
+func (h *Hub) Stats() Stats {
+	if h == nil {
+		return Stats{}
 	}
+	queueLen := 0
+	if h.asyncExec != nil {
+		queueLen = h.asyncExec.QueueLength()
+	}
+	h.statsMu.Lock()
+	plugins := make(map[string]PluginStats, len(h.pluginStats))
+	for name, st := range h.pluginStats {
+		plugins[name] = *st
+	}
+	h.statsMu.Unlock()
+	return Stats{AsyncQueueLength: queueLen, DroppedAsync: h.droppedAsync.Load(), Plugins: plugins}
+}
 
-	if len(h.asyncQueue) == 0 {
+func (h *Hub) PluginMetas() []PluginMeta {
+	if h == nil {
 		return nil
 	}
-
-	task := h.asyncQueue[0]
-	h.asyncQueue[0] = nil
-	h.asyncQueue = h.asyncQueue[1:]
-	return task
-}
-
-func (h *Hub) pushAsync(task func()) {
-	if task == nil {
-		return
+	h.pluginMetaMu.RLock()
+	defer h.pluginMetaMu.RUnlock()
+	out := make([]PluginMeta, 0, len(h.pluginMeta))
+	for _, meta := range h.pluginMeta {
+		out = append(out, meta)
 	}
-
-	h.asyncMu.Lock()
-	defer h.asyncMu.Unlock()
-
-	if h.ctx.Err() != nil {
-		return
-	}
-
-	h.asyncQueue = append(h.asyncQueue, task)
-	h.asyncCond.Signal()
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Stage == out[j].Stage {
+			return out[i].Priority < out[j].Priority
+		}
+		if out[i].Kind == out[j].Kind {
+			return out[i].Stage < out[j].Stage
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	return out
 }
 
 func (h *Hub) emitAsync(ctx Context, hooks []namedAsync, payload any) {
 	for _, hk := range hooks {
-		handler := hk.handler
-		c := ctx
-		p := payload
-
+		hook := hk
 		if h.ctx.Err() != nil {
 			return
 		}
-
-		h.pushAsync(func() { handler(c, p) })
+		queued := false
+		if h.asyncExec != nil {
+			queued = h.asyncExec.Submit(func() { h.runAsyncHandler(hook, ctx, payload) })
+		}
+		if !queued {
+			h.droppedAsync.Add(1)
+			h.recordDropped(hook.meta.Name)
+		}
 	}
 }
 
+func (h *Hub) runAsyncHandler(hk namedAsync, ctx Context, payload any) {
+	start := time.Now()
+	h.recordInvocation(hk.meta.Name)
+	if h.asyncConfig.Timeout <= 0 {
+		hk.handler(ctx, payload)
+		h.recordDuration(hk.meta.Name, time.Since(start))
+		return
+	}
+	baseCtx := ctx.Ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	deadlineCtx, cancel := context.WithTimeout(baseCtx, h.asyncConfig.Timeout)
+	defer cancel()
+	wrappedCtx := ctx
+	wrappedCtx.Ctx = deadlineCtx
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		hk.handler(wrappedCtx, payload)
+	}()
+	select {
+	case <-done:
+		h.recordDuration(hk.meta.Name, time.Since(start))
+	case <-deadlineCtx.Done():
+		h.recordTimeout(hk.meta.Name)
+		h.recordDuration(hk.meta.Name, time.Since(start))
+	}
+}
+
+func (h *Hub) recordPluginMeta(meta PluginMeta) {
+	h.pluginMetaMu.Lock()
+	defer h.pluginMetaMu.Unlock()
+	h.pluginMeta[meta.Name] = meta
+}
+
+func (h *Hub) ensurePluginStatsLocked(name string) *PluginStats {
+	if h.pluginStats[name] == nil {
+		h.pluginStats[name] = &PluginStats{}
+	}
+	return h.pluginStats[name]
+}
+
+func (h *Hub) recordInvocation(name string) {
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(name).Invocations++
+	h.statsMu.Unlock()
+}
+func (h *Hub) recordError(name string) {
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(name).Errors++
+	h.statsMu.Unlock()
+}
+func (h *Hub) recordStop(name string) {
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(name).Stops++
+	h.statsMu.Unlock()
+}
+func (h *Hub) recordTimeout(name string) {
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(name).Timeouts++
+	h.statsMu.Unlock()
+}
+func (h *Hub) recordDropped(name string) {
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(name).DroppedAsync++
+	h.statsMu.Unlock()
+}
+func (h *Hub) recordDuration(name string, duration time.Duration) {
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(name).TotalDurationMs += duration.Milliseconds()
+	h.statsMu.Unlock()
+}
+
 func (h *Hub) RegisterSync(event, name string, priority int, handler SyncHandler) {
+	h.RegisterSyncMeta(event, PluginMeta{Name: name, Priority: priority, Kind: PluginKindInterceptor, Stage: event}, handler)
+}
+
+func (h *Hub) RegisterSyncMeta(event string, meta PluginMeta, handler SyncHandler) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-
+	if meta.Name == "" {
+		meta.Name = event
+	}
+	meta.Kind = PluginKindInterceptor
+	meta.Stage = event
+	h.recordPluginMeta(meta)
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(meta.Name)
+	h.statsMu.Unlock()
 	cur := h.syncHandlers[event]
 	next := make([]namedSync, 0, len(cur)+1)
 	next = append(next, cur...)
-	next = append(next, namedSync{name: name, priority: priority, handler: handler})
-	sort.SliceStable(next, func(i, j int) bool { return next[i].priority < next[j].priority })
+	next = append(next, namedSync{meta: meta, handler: handler})
+	sort.SliceStable(next, func(i, j int) bool { return next[i].meta.Priority < next[j].meta.Priority })
 	h.syncHandlers[event] = next
 }
 
 func (h *Hub) RegisterAsync(event, name string, priority int, handler AsyncHandler) {
+	h.RegisterAsyncMeta(event, PluginMeta{Name: name, Priority: priority, Kind: PluginKindObserver, Stage: event}, handler)
+}
+
+func (h *Hub) RegisterAsyncMeta(event string, meta PluginMeta, handler AsyncHandler) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-
+	if meta.Name == "" {
+		meta.Name = event
+	}
+	meta.Kind = PluginKindObserver
+	meta.Stage = event
+	h.recordPluginMeta(meta)
+	h.statsMu.Lock()
+	h.ensurePluginStatsLocked(meta.Name)
+	h.statsMu.Unlock()
 	cur := h.asyncHandlers[event]
 	next := make([]namedAsync, 0, len(cur)+1)
 	next = append(next, cur...)
-	next = append(next, namedAsync{name: name, priority: priority, handler: handler})
-	sort.SliceStable(next, func(i, j int) bool { return next[i].priority < next[j].priority })
+	next = append(next, namedAsync{meta: meta, handler: handler})
+	sort.SliceStable(next, func(i, j int) bool { return next[i].meta.Priority < next[j].meta.Priority })
 	h.asyncHandlers[event] = next
 }
 
@@ -154,20 +425,23 @@ func (h *Hub) Emit(event string, ctx Context, payload any) (any, bool, error) {
 	syncs := h.syncHandlers[event]
 	asyncs := h.asyncHandlers[event]
 	h.mu.RUnlock()
-
 	out := payload
 	for _, hk := range syncs {
+		start := time.Now()
+		h.recordInvocation(hk.meta.Name)
 		next, stop, err := hk.handler(ctx, out)
+		h.recordDuration(hk.meta.Name, time.Since(start))
 		if err != nil {
-			return out, stop, fmt.Errorf("hook %s failed: %w", hk.name, err)
+			h.recordError(hk.meta.Name)
+			return out, stop, fmt.Errorf("hook %s failed: %w", hk.meta.Name, err)
 		}
 		out = next
 		if stop {
+			h.recordStop(hk.meta.Name)
 			h.emitAsync(ctx, asyncs, out)
 			return out, true, nil
 		}
 	}
-
 	h.emitAsync(ctx, asyncs, out)
 	return out, false, nil
 }

--- a/internal/pkg/hooks/hub_test.go
+++ b/internal/pkg/hooks/hub_test.go
@@ -73,3 +73,118 @@ func TestAsyncEmitDoesNotBlockWhenHandlersAreSlow(t *testing.T) {
 
 	close(release)
 }
+
+func TestAsyncQueueDropsWhenFull(t *testing.T) {
+	hub := NewHub(context.Background(), WithAsyncConfig(AsyncConfig{
+		QueueSize:    1,
+		WorkerCount:  1,
+		DropWhenFull: true,
+	}))
+	defer hub.Close()
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	hub.RegisterAsync("metric", "slow", 100, func(ctx Context, payload any) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+	})
+
+	for i := 0; i < 10; i++ {
+		if _, _, err := hub.Emit("metric", Context{}, i); err != nil {
+			t.Fatalf("Emit() error = %v", err)
+		}
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for async handler to start")
+	}
+
+	stats := hub.Stats()
+	if stats.DroppedAsync == 0 {
+		t.Fatalf("expected dropped async tasks > 0, got %+v", stats)
+	}
+	if stats.Plugins["slow"].DroppedAsync == 0 {
+		t.Fatalf("expected plugin dropped async tasks > 0, got %+v", stats.Plugins["slow"])
+	}
+
+	close(release)
+}
+
+func TestAsyncTimeoutIsAccounted(t *testing.T) {
+	hub := NewHub(context.Background(), WithAsyncConfig(AsyncConfig{Timeout: 20 * time.Millisecond}))
+	defer hub.Close()
+
+	hub.RegisterAsync("metric", "timeout-observer", 100, func(ctx Context, payload any) {
+		<-ctx.Ctx.Done()
+	})
+
+	if _, _, err := hub.Emit("metric", Context{Ctx: context.Background()}, 1); err != nil {
+		t.Fatalf("Emit() error = %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		stats := hub.Stats()
+		if stats.Plugins["timeout-observer"].Timeouts > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected timeout observer stats to be recorded, got %+v", hub.Stats().Plugins["timeout-observer"])
+}
+
+func TestSyncPluginStatsAreTracked(t *testing.T) {
+	hub := NewHub(context.Background())
+	defer hub.Close()
+
+	hub.RegisterSync("llm", "rewrite", 10, func(ctx Context, payload any) (any, bool, error) {
+		return payload, true, nil
+	})
+
+	if _, stop, err := hub.Emit("llm", Context{}, "hello"); err != nil {
+		t.Fatalf("Emit() error = %v", err)
+	} else if !stop {
+		t.Fatal("expected stop=true")
+	}
+
+	stats := hub.Stats().Plugins["rewrite"]
+	if stats.Invocations != 1 || stats.Stops != 1 {
+		t.Fatalf("unexpected sync plugin stats: %+v", stats)
+	}
+}
+
+func TestSharedAsyncExecutorAcrossHubs(t *testing.T) {
+	exec := NewAsyncExecutor(context.Background(), AsyncConfig{QueueSize: 16, WorkerCount: 1, DropWhenFull: false})
+	defer exec.Close()
+
+	hub1 := NewHub(context.Background(), WithAsyncExecutor(exec))
+	defer hub1.Close()
+	hub2 := NewHub(context.Background(), WithAsyncExecutor(exec))
+	defer hub2.Close()
+
+	got := make(chan int, 2)
+	hub1.RegisterAsync("metric", "hub1-observer", 100, func(ctx Context, payload any) { got <- payload.(int) })
+	hub2.RegisterAsync("metric", "hub2-observer", 100, func(ctx Context, payload any) { got <- payload.(int) })
+
+	if _, _, err := hub1.Emit("metric", Context{}, 1); err != nil {
+		t.Fatalf("hub1 Emit() error = %v", err)
+	}
+	if _, _, err := hub2.Emit("metric", Context{}, 2); err != nil {
+		t.Fatalf("hub2 Emit() error = %v", err)
+	}
+
+	seen := map[int]bool{}
+	for len(seen) < 2 {
+		select {
+		case v := <-got:
+			seen[v] = true
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting shared executor results, seen=%v", seen)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide a more governed, observable and extensible Chat Hook (Plugin V2) runtime that separates Interceptor and Observer semantics and prevents slow/rogue observers from impacting the main chat flow.
- Add plugin metadata, an explicit registry and lifecycle hooks to make builtin plugins manageable and configurable at runtime.
- Add bounded async execution, timeouts, drop strategy and per-plugin metrics to make observer execution predictable and measurable.

### Description

- Add a design document `ai_doc/chat_hook_plugin_v2_design.md` describing V2 goals, event model, runtime, payload contracts and migration plan.
- Add `chat_hooks` defaults to `config/config.yaml` and wire configuration into the runtime via `viper` for queue size, workers, drop strategy and timeout.
- Implement a new package-level hooks runtime in `internal/pkg/hooks` featuring `PluginMeta`, `AsyncExecutor`, per-plugin `Stats`, `Hub` options, bounded async queue with timeout/drop semantics, shared executor support and APIs to register/emit plugins with metadata.
- Introduce a domain-level façade in `internal/domain/chat/hooks` that adapts platform `Hub` to chat-typed payloads, exposes `Registration`/`BuiltinRegistrations`, `InitLifecycle` support and replaces old `RegisterSync`/`RegisterAsync` with `RegisterInterceptor`/`RegisterObserver` and `RegisterBuiltinPlugins` that accept overrides.
- Move the statistic plugin to the new registration model (`internal/domain/chat/hooks/statistic_plugin.go`) and provide lifecycle hooks for builtin plugins.
- Integrate the new hub and shared async executor into the chat server: `internal/app/server/chat/chat.go` creates a hub with `WithAsyncConfig`/`WithAsyncExecutor`, applies builtin plugin overrides from config, and logs loaded plugins; `internal/app/server/chat/session.go` and `tts.go` updated to align with new observer/interceptor semantics for metric and TTS events.
- Add `internal/pkg/hooks/hub_test.go` unit tests covering async non-blocking emits, queue dropping, timeout accounting, sync plugin stats tracking, and shared executor behavior.

### Testing

- Ran unit tests for the hooks package with `go test ./internal/pkg/hooks -v` and all tests including `TestAsyncQueueDropsWhenFull`, `TestAsyncTimeoutIsAccounted`, `TestSyncPluginStatsAreTracked` and `TestSharedAsyncExecutorAcrossHubs` passed.
- Ran package-level tests via `go test ./...` for modified packages and the test suites covering the new hub behavior completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea97c8e20832bb7849f2fd68f46e8)