### PR TITLE
Add global system prompt support (admin UI, persistence, and LLM integration)

### DIFF
--- a/internal/app/server/chat/llm.go
+++ b/internal/app/server/chat/llm.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
 	mcp_go "github.com/mark3labs/mcp-go/mcp"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -1300,6 +1301,14 @@ func (l *LLMManager) GetMessages(ctx context.Context, userMessage *schema.Messag
 
 	// 构建 system prompt
 	systemPrompt := l.clientState.SystemPrompt
+	globalSystemPrompt := strings.TrimSpace(viper.GetString("chat.global_system_prompt"))
+	if globalSystemPrompt != "" {
+		if systemPrompt != "" {
+			systemPrompt = globalSystemPrompt + "\n\n" + systemPrompt
+		} else {
+			systemPrompt = globalSystemPrompt
+		}
+	}
 
 	// 添加当前时间和日期信息
 	now := time.Now()

--- a/manager/backend/controllers/admin.go
+++ b/manager/backend/controllers/admin.go
@@ -3520,6 +3520,7 @@ func (ac *AdminController) GetChatSettings(c *gin.Context) {
 			"max_idle_duration":         30000,
 			"chat_max_silence_duration": 400,
 			"realtime_mode":             4,
+			"global_system_prompt":      "",
 		},
 	}
 
@@ -3546,6 +3547,9 @@ func (ac *AdminController) GetChatSettings(c *gin.Context) {
 			if realtimeMode, ok := chatData["realtime_mode"].(float64); ok && int(realtimeMode) >= 1 && int(realtimeMode) <= 4 {
 				response["chat"].(gin.H)["realtime_mode"] = int(realtimeMode)
 			}
+			if globalPrompt, ok := chatData["global_system_prompt"].(string); ok {
+				response["chat"].(gin.H)["global_system_prompt"] = strings.TrimSpace(globalPrompt)
+			}
 		}
 	}
 
@@ -3559,9 +3563,10 @@ func (ac *AdminController) UpdateChatSettings(c *gin.Context) {
 			Enable bool `json:"enable"`
 		} `json:"auth"`
 		Chat struct {
-			MaxIdleDuration        int64 `json:"max_idle_duration"`
-			ChatMaxSilenceDuration int64 `json:"chat_max_silence_duration"`
-			RealtimeMode           int   `json:"realtime_mode"`
+			MaxIdleDuration        int64  `json:"max_idle_duration"`
+			ChatMaxSilenceDuration int64  `json:"chat_max_silence_duration"`
+			RealtimeMode           int    `json:"realtime_mode"`
+			GlobalSystemPrompt     string `json:"global_system_prompt"`
 		} `json:"chat"`
 	}
 
@@ -3582,6 +3587,11 @@ func (ac *AdminController) UpdateChatSettings(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "chat.realtime_mode 必须在 1-4 之间"})
 		return
 	}
+	req.Chat.GlobalSystemPrompt = strings.TrimSpace(req.Chat.GlobalSystemPrompt)
+	if len(req.Chat.GlobalSystemPrompt) > 8000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "chat.global_system_prompt 长度不能超过 8000 个字符"})
+		return
+	}
 
 	authJSON, err := json.Marshal(map[string]interface{}{
 		"enable": req.Auth.Enable,
@@ -3594,6 +3604,7 @@ func (ac *AdminController) UpdateChatSettings(c *gin.Context) {
 		"max_idle_duration":         req.Chat.MaxIdleDuration,
 		"chat_max_silence_duration": req.Chat.ChatMaxSilenceDuration,
 		"realtime_mode":             req.Chat.RealtimeMode,
+		"global_system_prompt":      req.Chat.GlobalSystemPrompt,
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "chat 配置序列化失败"})
@@ -3670,6 +3681,7 @@ func (ac *AdminController) UpdateChatSettings(c *gin.Context) {
 				"max_idle_duration":         req.Chat.MaxIdleDuration,
 				"chat_max_silence_duration": req.Chat.ChatMaxSilenceDuration,
 				"realtime_mode":             req.Chat.RealtimeMode,
+				"global_system_prompt":      req.Chat.GlobalSystemPrompt,
 			},
 		},
 	})

--- a/manager/frontend/src/views/admin/ChatSettings.vue
+++ b/manager/frontend/src/views/admin/ChatSettings.vue
@@ -38,6 +38,19 @@
             <el-option :value="4" label="4 - asr出结果打断" />
           </el-select>
         </el-form-item>
+        <el-form-item label="全局System Prompt描述" prop="chat.global_system_prompt">
+          <el-input
+            v-model="form.chat.global_system_prompt"
+            type="textarea"
+            :rows="6"
+            maxlength="8000"
+            show-word-limit
+            placeholder="该内容会在系统提示词最前面拼接，建议填写平台级约束与身份设定。"
+          />
+          <div class="form-help">
+            生效顺序：全局System Prompt描述 → 角色/设备提示词 → 时间/记忆等运行时信息。
+          </div>
+        </el-form-item>
       </el-form>
     </el-card>
   </div>
@@ -59,7 +72,8 @@ const form = reactive({
   chat: {
     max_idle_duration: 30000,
     chat_max_silence_duration: 400,
-    realtime_mode: 4
+    realtime_mode: 4,
+    global_system_prompt: ''
   }
 })
 
@@ -72,6 +86,9 @@ const rules = {
   ],
   'chat.realtime_mode': [
     { required: true, message: '请选择实时打断模式', trigger: 'change' }
+  ],
+  'chat.global_system_prompt': [
+    { max: 8000, message: '全局System Prompt描述不能超过8000个字符', trigger: 'blur' }
   ]
 }
 
@@ -84,6 +101,7 @@ const loadSettings = async () => {
     form.chat.max_idle_duration = Number(data.chat?.max_idle_duration ?? 30000)
     form.chat.chat_max_silence_duration = Number(data.chat?.chat_max_silence_duration ?? 400)
     form.chat.realtime_mode = Number(data.chat?.realtime_mode ?? 4)
+    form.chat.global_system_prompt = String(data.chat?.global_system_prompt ?? '')
   } catch (error) {
     ElMessage.error('加载聊天设置失败')
     console.error(error)
@@ -106,7 +124,8 @@ const saveSettings = async () => {
       chat: {
         max_idle_duration: Number(form.chat.max_idle_duration),
         chat_max_silence_duration: Number(form.chat.chat_max_silence_duration),
-        realtime_mode: Number(form.chat.realtime_mode)
+        realtime_mode: Number(form.chat.realtime_mode),
+        global_system_prompt: String(form.chat.global_system_prompt || '')
       }
     })
     ElMessage.success('聊天设置保存成功')


### PR DESCRIPTION
### Motivation
- Provide a way to define a global System Prompt that is prepended to every chat session to enforce platform-level constraints and identity.

### Description
- Add `chat.global_system_prompt` to admin API responses and update handler, including trimming and a max length validation of 8000 characters.
- Persist `global_system_prompt` in the existing `chat` config JSON when saving chat settings.
- Add a textarea input to the admin frontend `ChatSettings.vue` to edit `global_system_prompt`, with client-side length validation and wiring to load/save flows.
- Load the `chat.global_system_prompt` at runtime in `LLMManager.GetMessages` (via `viper`) and prepend it to the session `systemPrompt` before adding time, memory, and speaker info.

### Testing
- Ran backend automated tests with `go test ./...`, which completed successfully.
- Built the frontend assets with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f57bb580832b9b6b1905d8f40ba6)