### PR TITLE
fix: preserve FunASR mode when reopening ASR config edits

### DIFF
--- a/manager/frontend/src/views/admin/forms/ASRConfigForm.vue
+++ b/manager/frontend/src/views/admin/forms/ASRConfigForm.vue
@@ -224,7 +224,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { InfoFilled } from '@element-plus/icons-vue'
 
 const props = defineProps({
@@ -234,14 +234,8 @@ const props = defineProps({
 
 const formRef = ref()
 
-watch(() => props.model?.provider, (provider) => {
-  if (provider === 'funasr' && props.model.funasr) {
-    props.model.funasr.mode = 'offline'
-  }
-}, { immediate: true })
-
 function onProviderChange() {
-  if (props.model.provider === 'funasr' && props.model.funasr) {
+  if (props.model.provider === 'funasr' && props.model.funasr && !props.model.funasr.mode) {
     props.model.funasr.mode = 'offline'
   }
 }


### PR DESCRIPTION
### Motivation
- The ASR config form was forcing `funasr.mode` to `offline` whenever the provider was `funasr`, which caused previously saved modes like `2pass` to be overwritten and displayed as `offline` when re-editing.

### Description
- Stop forcing `funasr.mode = 'offline'` unconditionally by removing the global `watch` and only defaulting to `offline` in `onProviderChange()` when `props.model.funasr.mode` is empty, and remove the unused `watch` import in `manager/frontend/src/views/admin/forms/ASRConfigForm.vue`.

### Testing
- Ran the frontend production build with `npm --prefix manager/frontend run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7ed67608832bac48da29c50861e1)