### PR TITLE
Support device-id and client-id from headers or URL query with extractor and validation

### DIFF
--- a/internal/app/server/websocket/websocket_server.go
+++ b/internal/app/server/websocket/websocket_server.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -144,12 +145,14 @@ func (s *WebSocketServer) handleMqttUdpChat(w http.ResponseWriter, r *http.Reque
 
 // handleWebSocket 处理 WebSocket 连接
 func (s *WebSocketServer) internalHandleChat(w http.ResponseWriter, r *http.Request, isMqttUdp bool) {
-	// 验证请求头
-	deviceID := r.Header.Get("Device-Id")
+	deviceID, clientID := extractDeviceAndClientID(r)
 	if deviceID == "" {
-		log.Warn("缺少 Device-Id 请求头")
-		http.Error(w, "缺少 Device-Id 请求头", http.StatusBadRequest)
+		log.Warn("缺少 device-id，请从 Header 或 URL 参数传入")
+		http.Error(w, "缺少 device-id（支持 Header 或 URL 参数）", http.StatusBadRequest)
 		return
+	}
+	if clientID == "" {
+		log.Debugf("连接未提供 client-id, device_id: %s", deviceID)
 	}
 
 	/*isAuth := viper.GetBool("auth.enable")
@@ -182,6 +185,50 @@ func (s *WebSocketServer) internalHandleChat(w http.ResponseWriter, r *http.Requ
 		s.onNewConnection(wsConn)
 	}
 
+}
+
+func extractDeviceAndClientID(r *http.Request) (string, string) {
+	deviceKeys := []string{"Device-Id", "device-id", "DEVICE-ID", "device_id", "Device_Id", "deviceId"}
+	clientKeys := []string{"Client-Id", "client-id", "CLIENT-ID", "client_id", "Client_Id", "clientId"}
+
+	headerDeviceID, headerDeviceKey := findHeaderValue(r.Header, deviceKeys)
+	queryDeviceID, queryDeviceKey := findQueryValue(r.URL.Query(), deviceKeys)
+	headerClientID, headerClientKey := findHeaderValue(r.Header, clientKeys)
+	queryClientID, queryClientKey := findQueryValue(r.URL.Query(), clientKeys)
+
+	deviceID := headerDeviceID
+	if deviceID == "" {
+		deviceID = queryDeviceID
+	} else if queryDeviceID != "" && queryDeviceID != headerDeviceID {
+		log.Warnf("device-id 在 Header(%s) 与 URL 参数(%s) 不一致，优先使用 Header 值", headerDeviceKey, queryDeviceKey)
+	}
+
+	clientID := headerClientID
+	if clientID == "" {
+		clientID = queryClientID
+	} else if queryClientID != "" && queryClientID != headerClientID {
+		log.Warnf("client-id 在 Header(%s) 与 URL 参数(%s) 不一致，优先使用 Header 值", headerClientKey, queryClientKey)
+	}
+
+	return deviceID, clientID
+}
+
+func findHeaderValue(header http.Header, keys []string) (string, string) {
+	for _, key := range keys {
+		if value := header.Get(key); value != "" {
+			return value, key
+		}
+	}
+	return "", ""
+}
+
+func findQueryValue(values url.Values, keys []string) (string, string) {
+	for _, key := range keys {
+		if value := values.Get(key); value != "" {
+			return value, key
+		}
+	}
+	return "", ""
 }
 
 func (s *WebSocketServer) handleInjectMsg(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Motivation
- Allow clients to provide `device-id` (and `client-id`) via either HTTP headers or URL query parameters to improve compatibility with different clients. 
- Accept multiple common header/query key variants and prefer header values when both header and query are present. 
- Provide clearer logging and error messages when `device-id` is missing or when header/query values conflict.

### Description
- Added `extractDeviceAndClientID` to unify retrieval of `device-id` and `client-id` from headers or URL query parameters and to prefer header values when both sources exist. 
- Implemented helper functions `findHeaderValue` and `findQueryValue` to search for multiple key variants (e.g. `Device-Id`, `device-id`, `device_id`, `deviceId`).
- Updated `internalHandleChat` to use `extractDeviceAndClientID`, changed the missing `device-id` error message, and added a debug log when `client-id` is not provided.
- Imported `net/url` and added warnings when header and query values conflict to make resolution explicit in logs.

### Testing
- Ran `go build ./...` which completed successfully. 
- Ran `go test ./...` which passed on the modified packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e193380c208323ae5eeae70fab22f8)