### PR TITLE
Frontend: move OpenAPI docs link, update docs code styling, improve role dialog UX, remove VAD controls

### DIFF
--- a/manager/frontend/src/views/Login.vue
+++ b/manager/frontend/src/views/Login.vue
@@ -80,9 +80,6 @@
           </el-form>
         </el-tab-pane>
       </el-tabs>
-      <div class="public-links">
-        <router-link to="/openapi-docs">查看公开 OpenAPI 接口说明</router-link>
-      </div>
     </el-card>
   </div>
 </template>
@@ -206,19 +203,6 @@ onMounted(() => {
 </script>
 
 <style scoped>
- .public-links {
-  margin-top: 8px;
-  text-align: center;
-  font-size: 13px;
-}
-.public-links a {
-  color: #409EFF;
-  text-decoration: none;
-}
-.public-links a:hover {
-  text-decoration: underline;
-}
-
 .login-container {
   display: flex;
   justify-content: center;

--- a/manager/frontend/src/views/OpenAPIDocs.vue
+++ b/manager/frontend/src/views/OpenAPIDocs.vue
@@ -261,7 +261,7 @@ const nav = [
 .method.post { background: #3b82f6; }
 .method.put { background: #f59e0b; }
 .method.delete { background: #ef4444; }
-pre { margin: 6px 0; background: #0f172a; color: #e5e7eb; border-radius: 8px; padding: 12px; overflow: auto; font-size: 12px; }
+pre { margin: 6px 0; background: #ffffff; color: #111827; border: 1px solid #d1d5db; border-radius: 8px; padding: 12px; overflow: auto; font-size: 12px; }
 code { background: #f3f4f6; padding: 2px 6px; border-radius: 4px; }
 table { width: 100%; border-collapse: collapse; font-size: 14px; }
 th, td { border: 1px solid #e5e7eb; padding: 8px; text-align: left; }

--- a/manager/frontend/src/views/user/APITokens.vue
+++ b/manager/frontend/src/views/user/APITokens.vue
@@ -4,6 +4,7 @@
       <div>
         <h2>API Token 管理</h2>
         <p class="page-subtitle">用于访问 /api/open/v1 对外接口，明文仅在创建时展示一次。</p>
+        <router-link class="doc-link" to="/openapi-docs">文档链接：查看公开 OpenAPI 接口说明</router-link>
       </div>
       <el-button type="primary" @click="openCreateDialog">
         <el-icon><Plus /></el-icon>
@@ -169,6 +170,14 @@ onMounted(loadTokens)
   margin-bottom: 12px;
 }
 .page-subtitle { margin: 4px 0 0; color: #909399; }
+.doc-link {
+  display: inline-block;
+  margin-top: 8px;
+  color: #409EFF;
+  text-decoration: none;
+  font-size: 13px;
+}
+.doc-link:hover { text-decoration: underline; }
 .table-card { margin-top: 12px; }
 .form-tip { color: #909399; font-size: 12px; margin-top: 6px; }
 .token-input { margin-top: 12px; }

--- a/manager/frontend/src/views/user/Roles.vue
+++ b/manager/frontend/src/views/user/Roles.vue
@@ -72,6 +72,7 @@
       v-model="showCreateDialog"
       :title="editingRole ? '编辑角色' : '创建角色'"
       width="800px"
+      class="role-dialog"
       @close="handleDialogClose"
     >
       <el-form
@@ -641,5 +642,45 @@ onMounted(() => {
 
 :deep(.dialog-sections .el-divider--horizontal) {
   margin: 8px 0 16px;
+}
+
+:deep(.role-dialog .el-dialog) {
+  width: min(800px, calc(100vw - 24px));
+  margin-top: 4vh;
+}
+
+:deep(.role-dialog .el-dialog__body) {
+  max-height: calc(100vh - 240px);
+  overflow-y: auto;
+  padding-bottom: 12px;
+}
+
+:deep(.role-dialog .el-dialog__footer) {
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  border-top: 1px solid #ebeef5;
+  z-index: 1;
+}
+
+@media (max-width: 768px) {
+  :deep(.role-dialog .el-dialog) {
+    width: calc(100vw - 16px);
+    margin-top: 2vh;
+  }
+
+  :deep(.role-dialog .el-dialog__body) {
+    max-height: calc(100vh - 180px);
+  }
+
+  :deep(.role-dialog .el-dialog__footer) {
+    padding: 12px 16px;
+    display: flex;
+    gap: 8px;
+  }
+
+  :deep(.role-dialog .el-dialog__footer .el-button) {
+    flex: 1;
+  }
 }
 </style>

--- a/manager/frontend/src/views/user/UserConsole.vue
+++ b/manager/frontend/src/views/user/UserConsole.vue
@@ -103,17 +103,6 @@
               
               <div class="device-features">
                 <div class="feature-item">
-                  <el-icon class="feature-icon"><Microphone /></el-icon>
-                  <span class="feature-label">语音识别</span>
-                  <el-switch 
-                    v-model="device.vad_status" 
-                    @change="toggleVAD(device)"
-                    :loading="device.loading"
-                    size="small"
-                  />
-                </div>
-                
-                <div class="feature-item">
                   <el-icon class="feature-icon"><User /></el-icon>
                   <span class="feature-label">智能体</span>
                   <span class="feature-value">{{ device.agent_name || '未绑定' }}</span>
@@ -268,12 +257,6 @@
             <el-form label-width="100px">
               <el-form-item label="音量">
                 <el-slider v-model="currentDevice.volume" :max="100" />
-              </el-form-item>
-              <el-form-item label="语音识别">
-                <el-switch 
-                  v-model="currentDevice.vad_status"
-                  @change="toggleVAD(currentDevice)"
-                />
               </el-form-item>
             </el-form>
           </div>
@@ -436,7 +419,6 @@ import {
   Connection,
   Plus,
   Setting,
-  Microphone,
   VideoPlay,
   VideoPause,
   Refresh,
@@ -467,7 +449,6 @@ const loadDevices = async () => {
     // 保存所有设备数据
     allDevicesData.value = allDevices.map(device => ({
       ...device,
-      loading: false,
       volume: device.volume || 80
     }))
     // 限制显示最多6个设备
@@ -493,22 +474,6 @@ const loadAgents = async () => {
     console.error('加载智能体失败:', error)
     ElMessage.error('加载智能体失败')
     agents.value = []
-  }
-}
-
-// 切换语音识别状态
-const toggleVAD = async (device) => {
-  device.loading = true
-  try {
-    // 模拟API调用
-    await new Promise(resolve => setTimeout(resolve, 1000))
-    device.vad_status = !device.vad_status
-    ElMessage.success(`${device.vad_status ? '启用' : '禁用'}语音识别成功`)
-  } catch (error) {
-    console.error('切换语音识别失败:', error)
-    ElMessage.error('操作失败')
-  } finally {
-    device.loading = false
   }
 }
 


### PR DESCRIPTION
### Motivation
- Surface the public OpenAPI documentation from a more appropriate place and remove it from the login view to declutter the auth screen. 
- Improve readability of code samples in the OpenAPI docs by switching to a light code block style. 
- Make the role create/edit dialog more usable on small screens by constraining width, enabling scrolling body, and making the footer sticky. 
- Simplify device UI by removing the VAD (voice activity detection) toggle and related state to reflect that the feature is no longer exposed in the console.

### Description
- Removed the public docs link from the login page by deleting the `.public-links` block in `src/views/Login.vue` and its CSS. 
- Added a prominent docs link to the API Tokens page at `src/views/user/APITokens.vue` and corresponding `.doc-link` styles. 
- Updated `src/views/OpenAPIDocs.vue` to change `pre` styling from a dark theme to a light background with border for better contrast and readability. 
- Enhanced the role dialog in `src/views/user/Roles.vue` by adding a `role-dialog` class and CSS to make the dialog responsive, set a max height with scrollable body, and a sticky footer for actions. 
- Removed VAD-related UI and logic from `src/views/user/UserConsole.vue`, including the microphone icon import, VAD switches in device cards and device control, the `loading` device flag initialization, and the `toggleVAD` function.

### Testing
- Ran linting with `npm run lint` and the checks passed. 
- Performed a production build with `npm run build` which completed successfully. 
- Ran the frontend unit/smoke tests (`npm test` / existing test runner) and no regressions were reported against the modified components.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c728e6788323921a933bc3ac3b01)