### PR TITLE
Set aliyun_qwen3 ASR `auto_end` default to false in backend and frontend

### DIFF
--- a/internal/domain/asr/aliyun_qwen3/config.go
+++ b/internal/domain/asr/aliyun_qwen3/config.go
@@ -13,7 +13,7 @@ const (
 	defaultFormat         = "pcm"
 	defaultSampleRate     = 16000
 	defaultLanguage       = "zh"
-	defaultAutoEnd        = true
+	defaultAutoEnd        = false
 	defaultVADThreshold   = 0.0
 	defaultVADSilenceMs   = 400
 	defaultTimeoutSeconds = 30

--- a/manager/frontend/src/views/admin/ASRConfig.vue
+++ b/manager/frontend/src/views/admin/ASRConfig.vue
@@ -186,7 +186,7 @@ const form = reactive({
     format: 'pcm',
     sample_rate: 16000,
     language: 'zh',
-    auto_end: true,
+    auto_end: false,
     vad_threshold: 0.0,
     vad_silence_ms: 400,
     timeout: 30
@@ -595,7 +595,7 @@ const resetForm = () => {
     format: 'pcm',
     sample_rate: 16000,
     language: 'zh',
-    auto_end: true,
+    auto_end: false,
     vad_threshold: 0.0,
     vad_silence_ms: 400,
     timeout: 30

--- a/manager/frontend/src/views/admin/ConfigWizard.vue
+++ b/manager/frontend/src/views/admin/ConfigWizard.vue
@@ -274,7 +274,7 @@ const asrForm = reactive({
     format: 'pcm',
     sample_rate: 16000,
     language: 'zh',
-    auto_end: true,
+    auto_end: false,
     vad_threshold: 0.0,
     vad_silence_ms: 400,
     timeout: 30


### PR DESCRIPTION
### Motivation
- Change the default behavior for the Aliyun Qwen3 ASR provider so sessions do not automatically end by default, reflecting a preference to require explicit end signaling rather than implicit auto-end.

### Description
- Update the backend default in `internal/domain/asr/aliyun_qwen3/config.go` by changing `defaultAutoEnd` from `true` to `false` so `AutoEnd` defaults to off.
- Update frontend initial form values in `manager/frontend/src/views/admin/ASRConfig.vue` and `manager/frontend/src/views/admin/ConfigWizard.vue` to set `auto_end` to `false` in the `aliyun_qwen3` provider blocks.

### Testing
- Ran backend unit tests with `go test ./...` and frontend test/build (`npm test` / `npm run build`) against the changed files, and the automated tests/build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c7484f4083299b7fdf2073b24be7)