### PR TITLE
fix(frontend): 对齐消息注入弹层单选项文本

### DIFF
--- a/manager/frontend/src/views/user/UserConsole.vue
+++ b/manager/frontend/src/views/user/UserConsole.vue
@@ -1401,6 +1401,8 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   width: 100%;
+  align-items: flex-start;
+  text-align: left;
 }
 
 .radio-title {
@@ -1441,6 +1443,8 @@ onMounted(() => {
   align-items: flex-start;
   height: auto;
   line-height: 1.4;
+  margin-left: 0;
+  padding-left: 0;
 }
 
 :deep(.inject-message-dialog .el-radio__input) {


### PR DESCRIPTION
### Motivation
- 修复控制台“消息注入”弹层中“进入监听”与其它单选项标题/描述未对齐的视觉问题。

### Description
- 在 `manager/frontend/src/views/user/UserConsole.vue` 中为 `.radio-option` 增加 `align-items: flex-start` 和 `text-align: left`，并为 `:deep(.inject-message-dialog .el-radio)` 增加 `margin-left: 0` 与 `padding-left: 0`，消除默认间距导致的错位。

### Testing
- 运行 `npm --prefix manager/frontend run -s lint`（项目未定义 `lint` 脚本），命令以非零退出码结束但与样式改动无关。
- 运行 `npm --prefix manager/frontend run -s build` 并成功完成构建。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4eb9c728c8329beaba933850101c8)