### PR TITLE
Add scheduler tasks: DB model, API endpoints, admin UI and local MCP scheduler tools

### DIFF
--- a/internal/domain/mcp/local_manager.go
+++ b/internal/domain/mcp/local_manager.go
@@ -39,6 +39,9 @@ func GetLocalMCPManager() *LocalMCPManager {
 
 // initDefaultTools 初始化默认的本地工具
 func (l *LocalMCPManager) initDefaultTools() {
+	if err := l.registerSchedulerTools(); err != nil {
+		log.Errorf("注册 scheduler 本地工具失败: %v", err)
+	}
 
 	log.Info("本地MCP管理器默认工具初始化完成")
 }

--- a/internal/domain/mcp/scheduler_tools.go
+++ b/internal/domain/mcp/scheduler_tools.go
@@ -1,0 +1,285 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type schedulerMutationInput struct {
+	Op      string              `json:"op" jsonschema:"description=操作类型:create/update/delete/enable/disable/run_now,enum=create,enum=update,enum=delete,enum=enable,enum=disable,enum=run_now"`
+	JobID   string              `json:"job_id,omitempty" jsonschema:"description=任务ID，update/delete/enable/disable/run_now时必填"`
+	Payload schedulerJobPayload `json:"payload,omitempty" jsonschema:"description=任务内容，create/update时必填"`
+}
+
+type schedulerJobPayload struct {
+	Name         string                 `json:"name,omitempty" jsonschema:"description=任务名称"`
+	ScheduleType string                 `json:"schedule_type,omitempty" jsonschema:"description=调度类型:once/interval/cron"`
+	RunAt        string                 `json:"run_at,omitempty" jsonschema:"description=一次性任务执行时间, RFC3339"`
+	CronExpr     string                 `json:"cron_expr,omitempty" jsonschema:"description=cron表达式"`
+	IntervalSec  int64                  `json:"interval_sec,omitempty" jsonschema:"description=周期秒数"`
+	Timezone     string                 `json:"timezone,omitempty" jsonschema:"description=时区"`
+	TaskMode     string                 `json:"task_mode,omitempty" jsonschema:"description=执行模式 inject_llm/mcp_call"`
+	TaskText     string                 `json:"task_text,omitempty" jsonschema:"description=注入到LLM的文本"`
+	ToolName     string                 `json:"tool_name,omitempty" jsonschema:"description=MCP工具名"`
+	Arguments    map[string]interface{} `json:"arguments,omitempty" jsonschema:"description=MCP工具参数"`
+}
+
+type schedulerQueryInput struct{}
+
+type schedulerJob struct {
+	JobID        string                 `json:"job_id"`
+	Name         string                 `json:"name"`
+	Enabled      bool                   `json:"enabled"`
+	ScheduleType string                 `json:"schedule_type"`
+	RunAt        string                 `json:"run_at,omitempty"`
+	CronExpr     string                 `json:"cron_expr,omitempty"`
+	IntervalSec  int64                  `json:"interval_sec,omitempty"`
+	Timezone     string                 `json:"timezone,omitempty"`
+	TaskMode     string                 `json:"task_mode,omitempty"`
+	TaskText     string                 `json:"task_text,omitempty"`
+	ToolName     string                 `json:"tool_name,omitempty"`
+	Arguments    map[string]interface{} `json:"arguments,omitempty"`
+	UpdatedAt    string                 `json:"updated_at"`
+	LastRunAt    string                 `json:"last_run_at,omitempty"`
+}
+
+type schedulerToolStore struct {
+	mu   sync.RWMutex
+	jobs map[string]schedulerJob
+}
+
+var defaultSchedulerStore = &schedulerToolStore{
+	jobs: make(map[string]schedulerJob),
+}
+
+func (l *LocalMCPManager) registerSchedulerTools() error {
+	if err := l.RegisterToolFunc(
+		"scheduler_query",
+		"查询当前已创建的调度任务数量（无需参数）",
+		schedulerQueryInput{},
+		handleSchedulerQueryTool,
+	); err != nil {
+		return err
+	}
+
+	if err := l.RegisterToolFunc(
+		"scheduler_mutation",
+		"统一处理调度任务的新增/更新/删除/启停/立即执行",
+		schedulerMutationInput{},
+		handleSchedulerMutationTool,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func handleSchedulerQueryTool(_ context.Context, _ string) (string, error) {
+	defaultSchedulerStore.mu.RLock()
+	total := len(defaultSchedulerStore.jobs)
+	defaultSchedulerStore.mu.RUnlock()
+
+	return marshalToolResult(map[string]interface{}{
+		"total":   total,
+		"message": fmt.Sprintf("当前共 %d 个调度任务", total),
+	}), nil
+}
+
+func handleSchedulerMutationTool(_ context.Context, argumentsInJSON string) (string, error) {
+	var req schedulerMutationInput
+	if strings.TrimSpace(argumentsInJSON) != "" {
+		if err := json.Unmarshal([]byte(argumentsInJSON), &req); err != nil {
+			return "", fmt.Errorf("解析参数失败: %w", err)
+		}
+	}
+
+	req.Op = strings.ToLower(strings.TrimSpace(req.Op))
+	switch req.Op {
+	case "create":
+		return handleSchedulerCreate(req)
+	case "update":
+		return handleSchedulerUpdate(req)
+	case "delete":
+		return handleSchedulerDelete(req)
+	case "enable":
+		return handleSchedulerEnableDisable(req, true)
+	case "disable":
+		return handleSchedulerEnableDisable(req, false)
+	case "run_now":
+		return handleSchedulerRunNow(req)
+	default:
+		return "", fmt.Errorf("不支持的 op: %s", req.Op)
+	}
+}
+
+func handleSchedulerCreate(req schedulerMutationInput) (string, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	jobID := strings.TrimSpace(req.JobID)
+	if jobID == "" {
+		jobID = fmt.Sprintf("job_%d", time.Now().UnixNano())
+	}
+
+	job := schedulerJob{
+		JobID:        jobID,
+		Name:         strings.TrimSpace(req.Payload.Name),
+		Enabled:      true,
+		ScheduleType: strings.TrimSpace(req.Payload.ScheduleType),
+		RunAt:        strings.TrimSpace(req.Payload.RunAt),
+		CronExpr:     strings.TrimSpace(req.Payload.CronExpr),
+		IntervalSec:  req.Payload.IntervalSec,
+		Timezone:     strings.TrimSpace(req.Payload.Timezone),
+		TaskMode:     strings.TrimSpace(req.Payload.TaskMode),
+		TaskText:     strings.TrimSpace(req.Payload.TaskText),
+		ToolName:     strings.TrimSpace(req.Payload.ToolName),
+		Arguments:    req.Payload.Arguments,
+		UpdatedAt:    now,
+	}
+
+	defaultSchedulerStore.mu.Lock()
+	defer defaultSchedulerStore.mu.Unlock()
+	if _, exists := defaultSchedulerStore.jobs[jobID]; exists {
+		return "", fmt.Errorf("任务已存在: %s", jobID)
+	}
+	defaultSchedulerStore.jobs[jobID] = job
+
+	return marshalToolResult(map[string]interface{}{
+		"ok":     true,
+		"op":     "create",
+		"job_id": jobID,
+	}), nil
+}
+
+func handleSchedulerUpdate(req schedulerMutationInput) (string, error) {
+	jobID := strings.TrimSpace(req.JobID)
+	if jobID == "" {
+		return "", fmt.Errorf("job_id 不能为空")
+	}
+
+	defaultSchedulerStore.mu.Lock()
+	defer defaultSchedulerStore.mu.Unlock()
+	job, exists := defaultSchedulerStore.jobs[jobID]
+	if !exists {
+		return "", fmt.Errorf("任务不存在: %s", jobID)
+	}
+
+	if name := strings.TrimSpace(req.Payload.Name); name != "" {
+		job.Name = name
+	}
+	if scheduleType := strings.TrimSpace(req.Payload.ScheduleType); scheduleType != "" {
+		job.ScheduleType = scheduleType
+	}
+	if runAt := strings.TrimSpace(req.Payload.RunAt); runAt != "" {
+		job.RunAt = runAt
+	}
+	if cronExpr := strings.TrimSpace(req.Payload.CronExpr); cronExpr != "" {
+		job.CronExpr = cronExpr
+	}
+	if req.Payload.IntervalSec > 0 {
+		job.IntervalSec = req.Payload.IntervalSec
+	}
+	if timezone := strings.TrimSpace(req.Payload.Timezone); timezone != "" {
+		job.Timezone = timezone
+	}
+	if taskMode := strings.TrimSpace(req.Payload.TaskMode); taskMode != "" {
+		job.TaskMode = taskMode
+	}
+	if taskText := strings.TrimSpace(req.Payload.TaskText); taskText != "" {
+		job.TaskText = taskText
+	}
+	if toolName := strings.TrimSpace(req.Payload.ToolName); toolName != "" {
+		job.ToolName = toolName
+	}
+	if req.Payload.Arguments != nil {
+		job.Arguments = req.Payload.Arguments
+	}
+	job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	defaultSchedulerStore.jobs[jobID] = job
+
+	return marshalToolResult(map[string]interface{}{
+		"ok":     true,
+		"op":     "update",
+		"job_id": jobID,
+	}), nil
+}
+
+func handleSchedulerDelete(req schedulerMutationInput) (string, error) {
+	jobID := strings.TrimSpace(req.JobID)
+	if jobID == "" {
+		return "", fmt.Errorf("job_id 不能为空")
+	}
+
+	defaultSchedulerStore.mu.Lock()
+	defer defaultSchedulerStore.mu.Unlock()
+	if _, exists := defaultSchedulerStore.jobs[jobID]; !exists {
+		return "", fmt.Errorf("任务不存在: %s", jobID)
+	}
+	delete(defaultSchedulerStore.jobs, jobID)
+
+	return marshalToolResult(map[string]interface{}{
+		"ok":     true,
+		"op":     "delete",
+		"job_id": jobID,
+	}), nil
+}
+
+func handleSchedulerEnableDisable(req schedulerMutationInput, enabled bool) (string, error) {
+	jobID := strings.TrimSpace(req.JobID)
+	if jobID == "" {
+		return "", fmt.Errorf("job_id 不能为空")
+	}
+
+	defaultSchedulerStore.mu.Lock()
+	defer defaultSchedulerStore.mu.Unlock()
+	job, exists := defaultSchedulerStore.jobs[jobID]
+	if !exists {
+		return "", fmt.Errorf("任务不存在: %s", jobID)
+	}
+	job.Enabled = enabled
+	job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	defaultSchedulerStore.jobs[jobID] = job
+
+	op := "disable"
+	if enabled {
+		op = "enable"
+	}
+
+	return marshalToolResult(map[string]interface{}{
+		"ok":      true,
+		"op":      op,
+		"job_id":  jobID,
+		"enabled": enabled,
+	}), nil
+}
+
+func handleSchedulerRunNow(req schedulerMutationInput) (string, error) {
+	jobID := strings.TrimSpace(req.JobID)
+	if jobID == "" {
+		return "", fmt.Errorf("job_id 不能为空")
+	}
+
+	defaultSchedulerStore.mu.Lock()
+	defer defaultSchedulerStore.mu.Unlock()
+	job, exists := defaultSchedulerStore.jobs[jobID]
+	if !exists {
+		return "", fmt.Errorf("任务不存在: %s", jobID)
+	}
+
+	job.LastRunAt = time.Now().UTC().Format(time.RFC3339)
+	job.UpdatedAt = job.LastRunAt
+	defaultSchedulerStore.jobs[jobID] = job
+
+	return marshalToolResult(map[string]interface{}{
+		"ok":          true,
+		"op":          "run_now",
+		"job_id":      jobID,
+		"last_run_at": job.LastRunAt,
+	}), nil
+}
+
+func marshalToolResult(v map[string]interface{}) string {
+	raw, _ := json.Marshal(v)
+	return string(raw)
+}

--- a/internal/domain/mcp/scheduler_tools_test.go
+++ b/internal/domain/mcp/scheduler_tools_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestSchedulerQuery_NoArgs(t *testing.T) {
+	resetSchedulerStoreForTest()
+
+	got, err := handleSchedulerQueryTool(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(got), &resp); err != nil {
+		t.Fatalf("unmarshal response failed: %v", err)
+	}
+	if resp["total"] != float64(0) {
+		t.Fatalf("expected total=0, got=%v", resp["total"])
+	}
+}
+
+func TestSchedulerMutation_CreateThenQuery(t *testing.T) {
+	resetSchedulerStoreForTest()
+
+	createArgs := `{"op":"create","payload":{"name":"daily","schedule_type":"cron","cron_expr":"0 0 8 * * *"}}`
+	if _, err := handleSchedulerMutationTool(context.Background(), createArgs); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	got, err := handleSchedulerQueryTool(context.Background(), "")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(got), &resp); err != nil {
+		t.Fatalf("unmarshal response failed: %v", err)
+	}
+	if resp["total"] != float64(1) {
+		t.Fatalf("expected total=1, got=%v", resp["total"])
+	}
+}
+
+func resetSchedulerStoreForTest() {
+	defaultSchedulerStore.mu.Lock()
+	defer defaultSchedulerStore.mu.Unlock()
+	defaultSchedulerStore.jobs = make(map[string]schedulerJob)
+}

--- a/manager/backend/controllers/scheduler_task.go
+++ b/manager/backend/controllers/scheduler_task.go
@@ -1,0 +1,195 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"xiaozhi/manager/backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+type schedulerTaskPayload struct {
+	Name         string                 `json:"name" binding:"required"`
+	Enabled      *bool                  `json:"enabled"`
+	ScheduleType string                 `json:"schedule_type"`
+	RunAt        *time.Time             `json:"run_at"`
+	CronExpr     string                 `json:"cron_expr"`
+	IntervalSec  int64                  `json:"interval_sec"`
+	Timezone     string                 `json:"timezone"`
+	TaskMode     string                 `json:"task_mode"`
+	TaskText     string                 `json:"task_text"`
+	ToolName     string                 `json:"tool_name"`
+	Arguments    map[string]interface{} `json:"arguments"`
+}
+
+type schedulerTaskResponse struct {
+	ID           uint                   `json:"id"`
+	Name         string                 `json:"name"`
+	Enabled      bool                   `json:"enabled"`
+	ScheduleType string                 `json:"schedule_type"`
+	RunAt        *time.Time             `json:"run_at,omitempty"`
+	CronExpr     string                 `json:"cron_expr,omitempty"`
+	IntervalSec  int64                  `json:"interval_sec,omitempty"`
+	Timezone     string                 `json:"timezone,omitempty"`
+	TaskMode     string                 `json:"task_mode"`
+	TaskText     string                 `json:"task_text,omitempty"`
+	ToolName     string                 `json:"tool_name,omitempty"`
+	Arguments    map[string]interface{} `json:"arguments,omitempty"`
+	CreatedAt    time.Time              `json:"created_at"`
+	UpdatedAt    time.Time              `json:"updated_at"`
+}
+
+func (ac *AdminController) GetSchedulerTasks(c *gin.Context) {
+	var tasks []models.SchedulerTask
+	if err := ac.DB.Order("created_at DESC").Find(&tasks).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取定时任务失败: " + err.Error()})
+		return
+	}
+
+	ret := make([]schedulerTaskResponse, 0, len(tasks))
+	for _, task := range tasks {
+		ret = append(ret, toSchedulerTaskResponse(task))
+	}
+	c.JSON(http.StatusOK, gin.H{"data": ret})
+}
+
+func (ac *AdminController) CreateSchedulerTask(c *gin.Context) {
+	var req schedulerTaskPayload
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "请求参数错误: " + err.Error()})
+		return
+	}
+
+	task, err := normalizeSchedulerTaskPayload(req, nil)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := ac.DB.Create(task).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建定时任务失败: " + err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": toSchedulerTaskResponse(*task)})
+}
+
+func (ac *AdminController) UpdateSchedulerTask(c *gin.Context) {
+	var task models.SchedulerTask
+	if err := ac.DB.First(&task, c.Param("id")).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "定时任务不存在"})
+		return
+	}
+
+	var req schedulerTaskPayload
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "请求参数错误: " + err.Error()})
+		return
+	}
+
+	updatedTask, err := normalizeSchedulerTaskPayload(req, &task)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := ac.DB.Save(updatedTask).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "更新定时任务失败: " + err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": toSchedulerTaskResponse(*updatedTask)})
+}
+
+func (ac *AdminController) DeleteSchedulerTask(c *gin.Context) {
+	if err := ac.DB.Delete(&models.SchedulerTask{}, c.Param("id")).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "删除定时任务失败: " + err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+}
+
+func normalizeSchedulerTaskPayload(req schedulerTaskPayload, existing *models.SchedulerTask) (*models.SchedulerTask, error) {
+	task := &models.SchedulerTask{}
+	if existing != nil {
+		*task = *existing
+	}
+
+	task.Name = strings.TrimSpace(req.Name)
+	if task.Name == "" {
+		return nil, fmt.Errorf("name 不能为空")
+	}
+
+	scheduleType := strings.ToLower(strings.TrimSpace(req.ScheduleType))
+	if scheduleType == "" {
+		scheduleType = "once"
+	}
+	if scheduleType != "once" && scheduleType != "interval" && scheduleType != "cron" {
+		return nil, fmt.Errorf("schedule_type 仅支持 once/interval/cron")
+	}
+	task.ScheduleType = scheduleType
+	task.RunAt = req.RunAt
+	task.CronExpr = strings.TrimSpace(req.CronExpr)
+	task.IntervalSec = req.IntervalSec
+	task.Timezone = strings.TrimSpace(req.Timezone)
+	if task.Timezone == "" {
+		task.Timezone = "Asia/Shanghai"
+	}
+
+	taskMode := strings.ToLower(strings.TrimSpace(req.TaskMode))
+	if taskMode == "" {
+		taskMode = "inject_llm"
+	}
+	if taskMode != "inject_llm" && taskMode != "mcp_call" {
+		return nil, fmt.Errorf("task_mode 仅支持 inject_llm/mcp_call")
+	}
+	task.TaskMode = taskMode
+	task.TaskText = strings.TrimSpace(req.TaskText)
+	task.ToolName = strings.TrimSpace(req.ToolName)
+	if req.Enabled != nil {
+		task.Enabled = *req.Enabled
+	} else if existing == nil {
+		task.Enabled = true
+	}
+
+	if req.Arguments != nil {
+		raw, err := json.Marshal(req.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		task.ArgumentsJSON = string(raw)
+	}
+	if task.TaskMode == "mcp_call" && task.ToolName == "" {
+		return nil, fmt.Errorf("task_mode=mcp_call 时 tool_name 不能为空")
+	}
+	if task.TaskMode == "inject_llm" && task.TaskText == "" {
+		return nil, fmt.Errorf("task_mode=inject_llm 时 task_text 不能为空")
+	}
+	return task, nil
+}
+
+func toSchedulerTaskResponse(task models.SchedulerTask) schedulerTaskResponse {
+	resp := schedulerTaskResponse{
+		ID:           task.ID,
+		Name:         task.Name,
+		Enabled:      task.Enabled,
+		ScheduleType: task.ScheduleType,
+		RunAt:        task.RunAt,
+		CronExpr:     task.CronExpr,
+		IntervalSec:  task.IntervalSec,
+		Timezone:     task.Timezone,
+		TaskMode:     task.TaskMode,
+		TaskText:     task.TaskText,
+		ToolName:     task.ToolName,
+		CreatedAt:    task.CreatedAt,
+		UpdatedAt:    task.UpdatedAt,
+	}
+	if strings.TrimSpace(task.ArgumentsJSON) != "" {
+		var args map[string]interface{}
+		if err := json.Unmarshal([]byte(task.ArgumentsJSON), &args); err == nil {
+			resp.Arguments = args
+		}
+	}
+	return resp
+}

--- a/manager/backend/controllers/setup.go
+++ b/manager/backend/controllers/setup.go
@@ -95,6 +95,7 @@ func (sc *SetupController) InitializeDatabase(c *gin.Context) {
 		&models.SpeakerGroup{},
 		&models.SpeakerSample{},
 		&models.ChatMessage{},
+		&models.SchedulerTask{},
 	)
 	if err != nil {
 		tx.Rollback()

--- a/manager/backend/database/database.go
+++ b/manager/backend/database/database.go
@@ -72,6 +72,7 @@ func Init(cfg config.DatabaseConfig) *gorm.DB {
 		&models.VoiceCloneAudio{},
 		&models.VoiceCloneTask{},
 		&models.UserVoiceCloneQuota{},
+		&models.SchedulerTask{},
 	)
 	if err != nil {
 		log.Printf("数据库表结构迁移失败: %v", err)

--- a/manager/backend/models/models.go
+++ b/manager/backend/models/models.go
@@ -337,3 +337,23 @@ func (m *ChatMessage) AfterFind(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+// SchedulerTask 定时任务模型（用于控制台增删改查）
+type SchedulerTask struct {
+	ID           uint       `json:"id" gorm:"primarykey"`
+	Name         string     `json:"name" gorm:"type:varchar(100);not null"`
+	Enabled      bool       `json:"enabled" gorm:"default:true;index"`
+	ScheduleType string     `json:"schedule_type" gorm:"type:varchar(20);not null;default:'once'"` // once/interval/cron
+	RunAt        *time.Time `json:"run_at"`
+	CronExpr     string     `json:"cron_expr" gorm:"type:varchar(120)"`
+	IntervalSec  int64      `json:"interval_sec" gorm:"default:0"`
+	Timezone     string     `json:"timezone" gorm:"type:varchar(64);default:'Asia/Shanghai'"`
+
+	TaskMode      string `json:"task_mode" gorm:"type:varchar(20);default:'inject_llm'"` // inject_llm/mcp_call
+	TaskText      string `json:"task_text" gorm:"type:text"`
+	ToolName      string `json:"tool_name" gorm:"type:varchar(100)"`
+	ArgumentsJSON string `json:"-" gorm:"type:text"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/manager/backend/router/router.go
+++ b/manager/backend/router/router.go
@@ -375,6 +375,10 @@ func Setup(db *gorm.DB, cfg *config.Config) *gin.Engine {
 				admin.POST("/agents/:id/mcp-call", adminController.CallAgentMcpTool)
 				admin.GET("/devices/:id/mcp-tools", adminController.GetDeviceMcpTools)
 				admin.POST("/devices/:id/mcp-call", adminController.CallDeviceMcpTool)
+				admin.GET("/scheduler-tasks", adminController.GetSchedulerTasks)
+				admin.POST("/scheduler-tasks", adminController.CreateSchedulerTask)
+				admin.PUT("/scheduler-tasks/:id", adminController.UpdateSchedulerTask)
+				admin.DELETE("/scheduler-tasks/:id", adminController.DeleteSchedulerTask)
 
 				// 用户管理
 				admin.GET("/users", adminController.GetUsers)

--- a/manager/frontend/src/components/Layout.vue
+++ b/manager/frontend/src/components/Layout.vue
@@ -118,6 +118,10 @@
           <el-icon><Connection /></el-icon>
           <span>智能体管理</span>
         </el-menu-item>
+        <el-menu-item v-if="authStore.isAdmin" index="/admin/scheduler-tasks">
+          <el-icon><Timer /></el-icon>
+          <span>定时任务</span>
+        </el-menu-item>
       </el-menu>
     </el-aside>
     
@@ -200,7 +204,8 @@ import {
   DataAnalysis,
   Guide,
   Upload,
-  Document
+  Document,
+  Timer
 } from '@element-plus/icons-vue'
 
 const router = useRouter()

--- a/manager/frontend/src/router/index.js
+++ b/manager/frontend/src/router/index.js
@@ -186,6 +186,12 @@ const routes = [
             name: 'AdminAgents',
             component: () => import('../views/admin/Agents.vue'),
             meta: { title: '智能体管理' }
+          },
+          {
+            path: 'scheduler-tasks',
+            name: 'AdminSchedulerTasks',
+            component: () => import('../views/admin/SchedulerTasks.vue'),
+            meta: { title: '定时任务管理' }
           }
         ]
       },

--- a/manager/frontend/src/views/admin/SchedulerTasks.vue
+++ b/manager/frontend/src/views/admin/SchedulerTasks.vue
@@ -1,0 +1,222 @@
+<template>
+  <div class="scheduler-tasks">
+    <div class="header">
+      <h2>定时任务管理</h2>
+      <el-button type="primary" @click="openCreate">新增任务</el-button>
+    </div>
+
+    <el-table :data="tasks" v-loading="loading" border>
+      <el-table-column prop="id" label="ID" width="80" />
+      <el-table-column prop="name" label="名称" min-width="180" />
+      <el-table-column prop="schedule_type" label="调度类型" width="110" />
+      <el-table-column label="执行时间/规则" min-width="220">
+        <template #default="{ row }">
+          <span v-if="row.schedule_type === 'once'">{{ formatDateTime(row.run_at) }}</span>
+          <span v-else-if="row.schedule_type === 'interval'">每 {{ row.interval_sec || 0 }} 秒</span>
+          <span v-else>{{ row.cron_expr || '-' }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column prop="task_mode" label="任务模式" width="120" />
+      <el-table-column prop="enabled" label="启用" width="90">
+        <template #default="{ row }">
+          <el-tag :type="row.enabled ? 'success' : 'info'">{{ row.enabled ? '是' : '否' }}</el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="240" fixed="right">
+        <template #default="{ row }">
+          <el-button size="small" @click="openEdit(row)">编辑</el-button>
+          <el-button size="small" type="warning" @click="toggleEnabled(row)">
+            {{ row.enabled ? '停用' : '启用' }}
+          </el-button>
+          <el-button size="small" type="danger" @click="remove(row)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialogVisible" :title="editingId ? '编辑任务' : '新增任务'" width="720px">
+      <el-form :model="form" label-width="120px">
+        <el-form-item label="任务名称">
+          <el-input v-model="form.name" />
+        </el-form-item>
+        <el-form-item label="调度类型">
+          <el-select v-model="form.schedule_type" style="width: 100%">
+            <el-option label="一次性" value="once" />
+            <el-option label="周期(秒)" value="interval" />
+            <el-option label="Cron" value="cron" />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-if="form.schedule_type === 'once'" label="执行时间">
+          <el-date-picker
+            v-model="form.run_at"
+            type="datetime"
+            value-format="YYYY-MM-DDTHH:mm:ssZ"
+            style="width: 100%"
+          />
+        </el-form-item>
+        <el-form-item v-if="form.schedule_type === 'interval'" label="周期秒数">
+          <el-input-number v-model="form.interval_sec" :min="1" />
+        </el-form-item>
+        <el-form-item v-if="form.schedule_type === 'cron'" label="Cron表达式">
+          <el-input v-model="form.cron_expr" placeholder="例如: 0 0 8 * * *" />
+        </el-form-item>
+        <el-form-item label="时区">
+          <el-input v-model="form.timezone" placeholder="Asia/Shanghai" />
+        </el-form-item>
+        <el-form-item label="任务模式">
+          <el-select v-model="form.task_mode" style="width: 100%">
+            <el-option label="注入LLM" value="inject_llm" />
+            <el-option label="调用MCP工具" value="mcp_call" />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-if="form.task_mode === 'inject_llm'" label="任务文本">
+          <el-input v-model="form.task_text" type="textarea" :rows="3" />
+        </el-form-item>
+        <el-form-item v-else label="工具名称">
+          <el-input v-model="form.tool_name" />
+        </el-form-item>
+        <el-form-item v-if="form.task_mode === 'mcp_call'" label="工具参数(JSON)">
+          <el-input v-model="argumentsText" type="textarea" :rows="4" />
+        </el-form-item>
+        <el-form-item label="启用">
+          <el-switch v-model="form.enabled" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="submit">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import api from '../../utils/api'
+
+const loading = ref(false)
+const tasks = ref([])
+const dialogVisible = ref(false)
+const editingId = ref(null)
+const argumentsText = ref('{}')
+
+const createDefaultForm = () => ({
+  name: '',
+  enabled: true,
+  schedule_type: 'once',
+  run_at: '',
+  cron_expr: '',
+  interval_sec: 60,
+  timezone: 'Asia/Shanghai',
+  task_mode: 'inject_llm',
+  task_text: '',
+  tool_name: '',
+  arguments: {}
+})
+
+const form = ref(createDefaultForm())
+
+const loadTasks = async () => {
+  loading.value = true
+  try {
+    const res = await api.get('/admin/scheduler-tasks')
+    tasks.value = res.data?.data || []
+  } catch (e) {
+    ElMessage.error(e.response?.data?.error || e.message || '加载定时任务失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const openCreate = () => {
+  editingId.value = null
+  form.value = createDefaultForm()
+  argumentsText.value = '{}'
+  dialogVisible.value = true
+}
+
+const openEdit = (row) => {
+  editingId.value = row.id
+  form.value = {
+    ...createDefaultForm(),
+    ...row
+  }
+  argumentsText.value = JSON.stringify(row.arguments || {}, null, 2)
+  dialogVisible.value = true
+}
+
+const submit = async () => {
+  try {
+    const parsedArgs = JSON.parse(argumentsText.value || '{}')
+    const payload = {
+      ...form.value,
+      arguments: parsedArgs
+    }
+    if (editingId.value) {
+      await api.put(`/admin/scheduler-tasks/${editingId.value}`, payload)
+      ElMessage.success('更新成功')
+    } else {
+      await api.post('/admin/scheduler-tasks', payload)
+      ElMessage.success('创建成功')
+    }
+    dialogVisible.value = false
+    await loadTasks()
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      ElMessage.error('工具参数 JSON 格式错误')
+      return
+    }
+    ElMessage.error(e.response?.data?.error || e.message || '保存失败')
+  }
+}
+
+const toggleEnabled = async (row) => {
+  try {
+    await api.put(`/admin/scheduler-tasks/${row.id}`, {
+      ...row,
+      enabled: !row.enabled
+    })
+    ElMessage.success('状态更新成功')
+    await loadTasks()
+  } catch (e) {
+    ElMessage.error(e.response?.data?.error || e.message || '更新状态失败')
+  }
+}
+
+const remove = async (row) => {
+  try {
+    await ElMessageBox.confirm(`确定删除任务「${row.name}」吗？`, '提示', {
+      type: 'warning'
+    })
+    await api.delete(`/admin/scheduler-tasks/${row.id}`)
+    ElMessage.success('删除成功')
+    await loadTasks()
+  } catch (e) {
+    if (e === 'cancel' || e === 'close') return
+    ElMessage.error(e.response?.data?.error || e.message || '删除失败')
+  }
+}
+
+const formatDateTime = (v) => {
+  if (!v) return '-'
+  const d = new Date(v)
+  if (Number.isNaN(d.getTime())) return v
+  return d.toLocaleString()
+}
+
+onMounted(loadTasks)
+</script>
+
+<style scoped>
+.scheduler-tasks {
+  padding: 20px;
+  background: #fff;
+  border-radius: 8px;
+}
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+</style>

--- a/manager/frontend/src/views/mobile/MobileMore.vue
+++ b/manager/frontend/src/views/mobile/MobileMore.vue
@@ -93,7 +93,8 @@ const systemItems = [
   { title: '全局角色', path: '/admin/global-roles' },
   { title: '用户管理', path: '/admin/users' },
   { title: '设备管理', path: '/admin/devices' },
-  { title: '智能体管理', path: '/admin/agents' }
+  { title: '智能体管理', path: '/admin/agents' },
+  { title: '定时任务', path: '/admin/scheduler-tasks' }
 ]
 
 const go = (path) => {


### PR DESCRIPTION
### Motivation

- Add support for creating, listing and managing scheduled tasks from the manager console and expose simple local MCP tools to query and mutate scheduler jobs.
- Persist scheduler definitions in the database so tasks can be managed via the admin UI and REST API.

### Description

- Introduce a new `SchedulerTask` GORM model to `manager/backend/models/models.go` and include it in automatic migrations in `database.go` and `setup.go`.
- Add CRUD HTTP handlers in `manager/backend/controllers/scheduler_task.go` with validation/normalization (`normalizeSchedulerTaskPayload`) and response mapping (`toSchedulerTaskResponse`), and register routes in `manager/backend/router/router.go` for `/admin/scheduler-tasks` endpoints.
- Implement a local in-memory scheduler MCP tool set in `internal/domain/mcp/scheduler_tools.go` and wire its registration into the local manager via `registerSchedulerTools()` called from `initDefaultTools()` in `local_manager.go`; the MCP tools provide `scheduler_query` and `scheduler_mutation` operations for create/update/delete/enable/disable/run_now.
- Add frontend admin UI: new view `SchedulerTasks.vue`, route entry in `manager/frontend/src/router/index.js`, menu items in `Layout.vue` and mobile navigation update in `MobileMore.vue` to manage scheduler tasks from the console.

### Testing

- Added unit tests in `internal/domain/mcp/scheduler_tools_test.go` covering query and create+query flows for the local scheduler store.
- Ran `go test ./internal/domain/mcp` and the new scheduler unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fa74fe18832ba7476a57395e84bd)