### PR TITLE
Use CSS grid for responsive card layouts and remove `el-row`/`el-col` wrappers

### DIFF
--- a/manager/frontend/src/views/admin/GlobalRoles.vue
+++ b/manager/frontend/src/views/admin/GlobalRoles.vue
@@ -7,8 +7,8 @@
       </el-button>
     </div>
 
-    <el-row :gutter="12" class="roles-grid" v-loading="loading">
-      <el-col :xs="24" :sm="12" :lg="8" v-for="role in roles" :key="role.id" class="role-col">
+    <div class="roles-grid" v-loading="loading">
+      <div v-for="role in roles" :key="role.id" class="role-col">
         <el-card class="role-card" shadow="hover">
           <template #header>
             <div class="card-header">
@@ -62,8 +62,8 @@
             </div>
           </div>
         </el-card>
-      </el-col>
-    </el-row>
+      </div>
+    </div>
 
     <el-empty v-if="!loading && roles.length === 0" description="暂无全局角色，点击右上角创建">
       <el-button type="primary" @click="showCreateDialog = true">创建第一个全局角色</el-button>
@@ -533,7 +533,11 @@ onMounted(() => {
 }
 
 .roles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 340px));
+  gap: 12px;
   align-items: stretch;
+  justify-content: flex-start;
 }
 
 .role-col {
@@ -542,8 +546,8 @@ onMounted(() => {
 }
 
 .role-card {
-  margin-bottom: 20px;
   width: 100%;
+  max-width: 340px;
   border-radius: 12px;
   border: 1px solid #ebeef5;
   transition: transform 0.2s ease, box-shadow 0.2s ease;

--- a/manager/frontend/src/views/user/AgentDevices.vue
+++ b/manager/frontend/src/views/user/AgentDevices.vue
@@ -843,8 +843,9 @@ watch(
 .devices-grid {
   margin-top: 20px;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(280px, 340px));
   gap: 16px;
+  justify-content: flex-start;
 }
 
 .device-item {
@@ -863,6 +864,7 @@ watch(
   flex-direction: column;
   width: 100%;
   min-width: 0;
+  max-width: 340px;
 }
 
 .device-card:hover {
@@ -1230,7 +1232,7 @@ watch(
 
 @media (min-width: 769px) and (max-width: 1180px) {
   .devices-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(280px, 340px));
   }
 }
 </style>

--- a/manager/frontend/src/views/user/Agents.vue
+++ b/manager/frontend/src/views/user/Agents.vue
@@ -735,9 +735,10 @@ onMounted(async () => {
 
 .agents-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(280px, 340px));
   gap: 16px;
   align-content: flex-start;
+  justify-content: flex-start;
 }
 
 .agent-card {
@@ -746,6 +747,8 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: 14px;
+  max-width: 340px;
+  width: 100%;
 }
 
 .agent-card-skeleton {
@@ -1079,7 +1082,7 @@ onMounted(async () => {
 
 @media (min-width: 769px) and (max-width: 1180px) {
   .agents-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(280px, 340px));
   }
 }
 

--- a/manager/frontend/src/views/user/Roles.vue
+++ b/manager/frontend/src/views/user/Roles.vue
@@ -8,8 +8,8 @@
     </div>
 
     <!-- 角色卡片列表 -->
-    <el-row :gutter="12" class="roles-grid" v-loading="loading">
-      <el-col :xs="24" :sm="12" :lg="8" v-for="role in userRoles" :key="role.id" class="role-col">
+    <div class="roles-grid" v-loading="loading">
+      <div v-for="role in userRoles" :key="role.id" class="role-col">
         <el-card class="role-card" shadow="hover">
           <template #header>
             <div class="card-header">
@@ -58,8 +58,8 @@
             </div>
           </div>
         </el-card>
-      </el-col>
-    </el-row>
+      </div>
+    </div>
 
     <!-- 空状态 -->
     <el-empty v-if="!loading && userRoles.length === 0" description="暂无角色，点击右上角创建">
@@ -492,7 +492,11 @@ onMounted(() => {
 }
 
 .roles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 340px));
+  gap: 12px;
   align-items: stretch;
+  justify-content: flex-start;
 }
 
 .role-col {
@@ -501,8 +505,8 @@ onMounted(() => {
 }
 
 .role-card {
-  margin-bottom: 20px;
   width: 100%;
+  max-width: 340px;
   border-radius: 12px;
   border: 1px solid #ebeef5;
   transition: transform 0.2s ease, box-shadow 0.2s ease;


### PR DESCRIPTION
### Motivation
- Improve responsive behavior and card sizing for lists of roles, agents, and devices by moving from `el-row`/`el-col` layout to native CSS grid and fixed card max widths.
- Standardize card widths and spacing across multiple views to avoid uneven columns and improve layout on varying viewport sizes.

### Description
- Replaced `el-row`/`el-col` wrappers with plain `div` containers in `manager/frontend/src/views/admin/GlobalRoles.vue` and `manager/frontend/src/views/user/Roles.vue` to simplify markup for card grids.
- Switched grid templates to `repeat(auto-fill, minmax(280px, 340px))` and added `display: grid`, `gap: 12px`/`16px`, and `justify-content: flex-start` in `GlobalRoles.vue`, `Roles.vue`, `Agents.vue`, and `AgentDevices.vue` to make card layout responsive.
- Added `max-width: 340px` (and `width: 100%` where appropriate) to card elements and removed extra margins so cards maintain consistent sizing and alignment.
- Minor visual adjustments including hover transformations and preserved existing card header/body padding via `:deep` selectors.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef06f540288323b24bde272c7b1368)