### PR TITLE
fix: normalize MAC formats when binding device

### DIFF
--- a/manager/backend/controllers/user.go
+++ b/manager/backend/controllers/user.go
@@ -227,7 +227,21 @@ func isSixDigitCode(value string) bool {
 }
 
 func normalizeDeviceNameCandidate(value string) string {
-	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "-", ":"))
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	// 兼容常见 MAC 分隔符，统一归一化为 12 位十六进制串进行匹配
+	replacer := strings.NewReplacer(
+		":", "",
+		"-", "",
+		".", "",
+		" ", "",
+		"：", "",
+	)
+	normalized := strings.ToLower(replacer.Replace(trimmed))
+	return normalized
 }
 
 func normalizeDeviceNickName(value string) (string, error) {
@@ -708,7 +722,14 @@ func (uc *UserController) AddDeviceToAgent(c *gin.Context) {
 		}
 	} else {
 		normalizedDeviceName := normalizeDeviceNameCandidate(deviceName)
-		if err := query.Where("LOWER(REPLACE(device_name, '-', ':')) = ?", normalizedDeviceName).First(&device).Error; err != nil {
+		if normalizedDeviceName == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "设备MAC无效或设备已被绑定"})
+			return
+		}
+		if err := query.Where(
+			"LOWER(REPLACE(REPLACE(REPLACE(REPLACE(device_name, '-', ''), ':', ''), '.', ''), ' ', '')) = ?",
+			normalizedDeviceName,
+		).First(&device).Error; err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "设备MAC无效或设备已被绑定"})
 			return
 		}

--- a/manager/backend/controllers/user_device_name_test.go
+++ b/manager/backend/controllers/user_device_name_test.go
@@ -1,0 +1,27 @@
+package controllers
+
+import "testing"
+
+func TestNormalizeDeviceNameCandidate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "colon mac", in: "28:0A:C6:1D:3B:E8", want: "280ac61d3be8"},
+		{name: "dash mac", in: "28-0A-C6-1D-3B-E8", want: "280ac61d3be8"},
+		{name: "dot mac", in: "280A.C61D.3BE8", want: "280ac61d3be8"},
+		{name: "full width colon", in: "28：0A：C6：1D：3B：E8", want: "280ac61d3be8"},
+		{name: "plain mac", in: "280AC61D3BE8", want: "280ac61d3be8"},
+		{name: "with spaces", in: " 28:0A:C6:1D:3B:E8 ", want: "280ac61d3be8"},
+		{name: "empty", in: "   ", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeDeviceNameCandidate(tt.in); got != tt.want {
+				t.Fatalf("normalizeDeviceNameCandidate(%q)=%q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- 修复控制台添加/绑定设备时，明明填了正确的 MAC 但后端因分隔符格式不同报 “mac 地址格式不正确” 的问题。

### Description

- 将 `normalizeDeviceNameCandidate` 改为去除常见分隔符（`:` `-` `.` 空格 全角冒号`），并统一转为小写以归一化输入。 
- 在 `AddDeviceToAgent` 中把数据库查询改为在 SQL 层同样去除分隔符后比较 `device_name`，避免分隔符差异导致匹配失败。 
- 新增单元测试 `manager/backend/controllers/user_device_name_test.go`，覆盖多种 MAC 输入形式（冒号、短横、点分、全角、无分隔及带空格）。

### Testing

- 在 `manager/backend` 目录运行 `go test ./controllers -run TestNormalizeDeviceNameCandidate`，测试通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef724faf38832397b76fc2872cacd7)