### PR TITLE
修复 MCP 工具名 OpenAI 兼容问题

### DIFF
--- a/internal/domain/mcp/device_manager.go
+++ b/internal/domain/mcp/device_manager.go
@@ -346,8 +346,7 @@ func (dc *McpClientInstance) toolCount() int {
 
 func (dc *McpClientInstance) getToolByName(toolName string) (tool.InvokableTool, bool) {
 	tools := dc.loadToolsSnapshot()
-	invokable, ok := tools[toolName]
-	return invokable, ok
+	return findInvokableToolByName(tools, toolName)
 }
 
 func (dc *McpClientInstance) setConnected(connected bool) {
@@ -921,6 +920,9 @@ func (dc *DeviceMcpSession) RawCallIotToolByTransport(ctx context.Context, trans
 		return "", false, nil
 	}
 
+	if invokable, ok := iotClient.getToolByName(toolName); ok {
+		toolName = remoteCallNameForTool(invokable, toolName)
+	}
 	result, err := iotClient.RawCallTool(ctx, toolName, arguments)
 	return result, true, err
 }
@@ -938,6 +940,9 @@ func (dc *DeviceMcpSession) RawCallWsEndpointTool(ctx context.Context, toolName 
 		return "", false, nil
 	}
 
+	if invokable, ok := selected.getToolByName(toolName); ok {
+		toolName = remoteCallNameForTool(invokable, toolName)
+	}
 	result, err := selected.RawCallTool(ctx, toolName, arguments)
 	return result, true, err
 }

--- a/internal/domain/mcp/global_manage.go
+++ b/internal/domain/mcp/global_manage.go
@@ -540,7 +540,17 @@ func (conn *MCPServerConnection) refreshTools(ctx context.Context) error {
 
 func ConvertMcpToolListToInvokableToolList(tools []mcp.Tool, serverName string, client *client.Client) map[string]tool.InvokableTool {
 	invokeTools := make(map[string]tool.InvokableTool)
+	usedNames := make(map[string]string, len(tools))
 	for _, tool := range tools {
+		originName := tool.Name
+		if strings.TrimSpace(originName) == "" {
+			log.Warnf("跳过空名称 MCP 工具, server=%s", serverName)
+			continue
+		}
+		llmName := uniqueLLMToolName(sanitizeLLMToolName(originName), originName, usedNames)
+		if llmName != originName {
+			log.Debugf("MCP工具名 %q 不符合OpenAI工具名规范，已转换为 %q, server=%s", originName, llmName, serverName)
+		}
 
 		marshaledInputSchema, err := sonic.Marshal(tool.InputSchema)
 		if err != nil {
@@ -556,14 +566,15 @@ func ConvertMcpToolListToInvokableToolList(tools []mcp.Tool, serverName string, 
 
 		mcpToolInstance := &McpTool{
 			info: &schema.ToolInfo{
-				Name:        tool.Name,
+				Name:        llmName,
 				Desc:        tool.Description,
 				ParamsOneOf: schema.NewParamsOneOfByOpenAPIV3(inputSchema),
 			},
+			originName: originName,
 			serverName: serverName,
 			client:     client,
 		}
-		invokeTools[tool.Name] = mcpToolInstance
+		invokeTools[llmName] = mcpToolInstance
 	}
 	return invokeTools
 }
@@ -645,8 +656,7 @@ func (g *GlobalMCPManager) GetToolByName(name string) (tool.InvokableTool, bool)
 	var matched tool.InvokableTool
 	matchCount := 0
 	for _, invokable := range g.tools {
-		mcpToolInstance, ok := invokable.(*McpTool)
-		if !ok || mcpToolInstance.info == nil || mcpToolInstance.info.Name != name {
+		if !mcpToolMatchesName(invokable, name) {
 			continue
 		}
 		matchCount++

--- a/internal/domain/mcp/mcp_client.go
+++ b/internal/domain/mcp/mcp_client.go
@@ -444,8 +444,7 @@ func GetReportedToolByAgentIDAndName(agentId, toolName string) (tool.InvokableTo
 		return nil, false
 	}
 
-	invokable, ok := reportedTools[toolName]
-	return invokable, ok
+	return findInvokableToolByName(reportedTools, toolName)
 }
 
 func RawCallReportedToolByDeviceID(deviceId, toolName string, arguments map[string]interface{}) (string, bool, error) {

--- a/internal/domain/mcp/mcp_test.go
+++ b/internal/domain/mcp/mcp_test.go
@@ -480,6 +480,70 @@ func TestMCPToolInvokableRunReconnectsOnRetryableRemoteCallError(t *testing.T) {
 	assert.Same(t, reconnectedClient, testTool.client)
 }
 
+func TestMCPToolInvokableRunUsesOriginNameForRemoteCall(t *testing.T) {
+	originalCallRemoteMCPTool := callRemoteMCPTool
+	t.Cleanup(func() {
+		callRemoteMCPTool = originalCallRemoteMCPTool
+	})
+
+	var calledName string
+	callRemoteMCPTool = func(ctx context.Context, cli *client.Client, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		calledName = request.Params.Name
+		return mcp.NewToolResultText("ok"), nil
+	}
+
+	testTool := &McpTool{
+		info:       &schema.ToolInfo{Name: "browser_click", Desc: "click"},
+		originName: "browser.click",
+		serverName: "browser",
+		client:     new(client.Client),
+	}
+
+	_, err := testTool.InvokableRun(context.Background(), `{}`)
+	require.NoError(t, err)
+	assert.Equal(t, "browser.click", calledName)
+}
+
+func TestConvertMcpToolListToInvokableToolListSanitizesInvalidNames(t *testing.T) {
+	tools := []mcp.Tool{
+		mcp.NewTool("browser.click", mcp.WithDescription("click")),
+		mcp.NewTool("中文工具", mcp.WithDescription("unicode")),
+		mcp.NewTool("browser click", mcp.WithDescription("space")),
+	}
+
+	converted := ConvertMcpToolListToInvokableToolList(tools, "test_server", new(client.Client))
+
+	require.Contains(t, converted, "browser_click")
+	require.Contains(t, converted, "tool_f14843ab")
+	require.Contains(t, converted, "browser_click_29a678e7")
+
+	info, err := converted["browser_click"].(*McpTool).Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "browser_click", info.Name)
+	assert.Equal(t, "browser.click", converted["browser_click"].(*McpTool).originName)
+}
+
+func TestMcpClientInstanceGetToolByNameMatchesOriginName(t *testing.T) {
+	sanitizedTool := &McpTool{
+		info:       &schema.ToolInfo{Name: "browser_click"},
+		originName: "browser.click",
+	}
+	instance := &McpClientInstance{
+		tools: map[string]einotool.InvokableTool{
+			"browser_click": sanitizedTool,
+		},
+	}
+	instance.storeToolsSnapshot(instance.tools)
+
+	invokable, ok := instance.getToolByName("browser_click")
+	require.True(t, ok)
+	assert.Same(t, sanitizedTool, invokable)
+
+	invokable, ok = instance.getToolByName("browser.click")
+	require.True(t, ok)
+	assert.Same(t, sanitizedTool, invokable)
+}
+
 func TestFilterMCPToolsByAllowList(t *testing.T) {
 	tools := []mcp.Tool{
 		{Name: "alerts"},

--- a/internal/domain/mcp/mcp_tool.go
+++ b/internal/domain/mcp/mcp_tool.go
@@ -26,6 +26,7 @@ type LocalToolHandler func(ctx context.Context, argumentsInJSON string) (string,
 // mcpTool MCP工具实现，支持远程和本地工具
 type McpTool struct {
 	info       *schema.ToolInfo
+	originName string
 	serverName string
 	client     *client.Client
 
@@ -37,6 +38,48 @@ type McpTool struct {
 // Info 获取工具信息，实现BaseTool接口
 func (t *McpTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return t.info, nil
+}
+
+func (t *McpTool) callName() string {
+	if t.originName != "" {
+		return t.originName
+	}
+	if t.info != nil {
+		return t.info.Name
+	}
+	return ""
+}
+
+func mcpToolMatchesName(invokable tool.InvokableTool, name string) bool {
+	mcpTool, ok := invokable.(*McpTool)
+	if !ok || mcpTool == nil {
+		return false
+	}
+	if mcpTool.info != nil && mcpTool.info.Name == name {
+		return true
+	}
+	return mcpTool.originName != "" && mcpTool.originName == name
+}
+
+func findInvokableToolByName(tools map[string]tool.InvokableTool, name string) (tool.InvokableTool, bool) {
+	if invokable, ok := tools[name]; ok {
+		return invokable, true
+	}
+	for _, invokable := range tools {
+		if mcpToolMatchesName(invokable, name) {
+			return invokable, true
+		}
+	}
+	return nil, false
+}
+
+func remoteCallNameForTool(invokable tool.InvokableTool, fallback string) string {
+	if mcpTool, ok := invokable.(*McpTool); ok && mcpTool != nil {
+		if name := mcpTool.callName(); name != "" {
+			return name
+		}
+	}
+	return fallback
 }
 
 func (t *McpTool) InvokeableLocalRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
@@ -85,9 +128,10 @@ func (t *McpTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts
 	}
 
 	// 准备调用请求
+	toolName := t.callName()
 	callRequest := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
-			Name:      t.info.Name,
+			Name:      toolName,
 			Arguments: arguments,
 		},
 	}

--- a/internal/domain/mcp/tool_name.go
+++ b/internal/domain/mcp/tool_name.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
+
+const llmToolNameMaxLen = 64
+
+func sanitizeLLMToolName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(trimmed))
+	hasAlphaNum := false
+	lastWasReplacement := false
+	for _, r := range trimmed {
+		if isLLMToolNameAlphaNum(r) {
+			b.WriteRune(r)
+			hasAlphaNum = true
+			lastWasReplacement = false
+			continue
+		}
+		if isLLMToolNamePunct(r) {
+			b.WriteRune(r)
+			lastWasReplacement = false
+			continue
+		}
+		if !lastWasReplacement {
+			b.WriteByte('_')
+			lastWasReplacement = true
+		}
+	}
+
+	sanitized := strings.Trim(b.String(), "_-")
+	if sanitized == "" || !hasAlphaNum {
+		sanitized = "tool_" + shortStableHash(trimmed)
+	}
+	return truncateLLMToolName(sanitized, trimmed)
+}
+
+func uniqueLLMToolName(candidate, original string, used map[string]string) string {
+	if candidate == "" {
+		candidate = "tool_" + shortStableHash(original)
+	}
+	if used == nil {
+		return candidate
+	}
+
+	if prev, ok := used[candidate]; !ok || prev == original {
+		used[candidate] = original
+		return candidate
+	}
+
+	hashSuffix := "_" + shortStableHash(original)
+	base := strings.Trim(candidate, "_-")
+	if base == "" {
+		base = "tool"
+	}
+
+	for i := 0; ; i++ {
+		extraSuffix := ""
+		if i > 0 {
+			extraSuffix = fmt.Sprintf("_%d", i+1)
+		}
+		maxBaseLen := llmToolNameMaxLen - len(hashSuffix) - len(extraSuffix)
+		if maxBaseLen < 1 {
+			maxBaseLen = 1
+		}
+
+		trimmedBase := base
+		if len(trimmedBase) > maxBaseLen {
+			trimmedBase = strings.Trim(trimmedBase[:maxBaseLen], "_-")
+			if trimmedBase == "" {
+				trimmedBase = "tool"
+			}
+		}
+
+		name := trimmedBase + hashSuffix + extraSuffix
+		if prev, ok := used[name]; !ok || prev == original {
+			used[name] = original
+			return name
+		}
+	}
+}
+
+func isLLMToolNameAlphaNum(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func isLLMToolNamePunct(r rune) bool {
+	return r == '_' || r == '-'
+}
+
+func truncateLLMToolName(name, original string) string {
+	if len(name) <= llmToolNameMaxLen {
+		return name
+	}
+
+	hashSuffix := "_" + shortStableHash(original)
+	maxBaseLen := llmToolNameMaxLen - len(hashSuffix)
+	if maxBaseLen < 1 {
+		maxBaseLen = 1
+	}
+
+	base := strings.Trim(name[:maxBaseLen], "_-")
+	if base == "" {
+		base = "tool"
+	}
+	return base + hashSuffix
+}
+
+func shortStableHash(value string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(value))
+	return fmt.Sprintf("%08x", h.Sum32())
+}


### PR DESCRIPTION
## Summary
- sanitize MCP tool names before exposing them to Eino/OpenAI-compatible tool calling
- keep original MCP tool names for remote tools/call execution
- support lookup by both sanitized alias and original tool name
- downgrade normalization logs to debug to avoid refresh-time log noise

## Tests
- go test ./internal/domain/mcp -count=1