### PR TITLE
修复本地VAD首段音频保存裁剪

### DIFF
--- a/internal/app/server/chat/asr.go
+++ b/internal/app/server/chat/asr.go
@@ -26,6 +26,8 @@ import (
 
 type ASRManagerOption func(*ASRManager)
 
+const maxFirstSpeechPreAudioMs = 200
+
 // AsrMessageSaveCallback 消息保存回调函数类型
 type AsrMessageSaveCallback func(userMsg *schema.Message, messageID string, audioData []float32)
 
@@ -303,8 +305,9 @@ func (a *ASRManager) ProcessVadAudio(ctx context.Context) {
 						//首次触发识别到语音时,为了语音数据完整性 将vadPcmData赋值给pcmData, 之后的音频数据全部进入asr
 						if haveVoice && !clientHaveVoice {
 							//首次检测到语音时，最多只保留200ms的前静音数据
+							currentFrameSamples := len(pcmData)
 							allData := state.AsrAudioBuffer.GetAndClearAllData()
-							pcmData = allData
+							pcmData = trimFirstSpeechAudio(allData, currentFrameSamples, audioFormat.SampleRate, audioFormat.Channels)
 						}
 					}
 					//log.Debugf("isVad, pcmData len: %d, vadPcmData len: %d, haveVoice: %v", len(pcmData), len(vadPcmData), haveVoice)
@@ -1038,6 +1041,25 @@ func (a *ASRManager) StartAsrRecognitionLoop(
 			}
 		}
 	}()
+}
+
+func trimFirstSpeechAudio(allData []float32, currentFrameSamples, sampleRate, channels int) []float32 {
+	if len(allData) == 0 {
+		return nil
+	}
+	if currentFrameSamples <= 0 || currentFrameSamples > len(allData) || sampleRate <= 0 || channels <= 0 {
+		return allData
+	}
+
+	maxPreSpeechSamples := sampleRate * channels * maxFirstSpeechPreAudioMs / 1000
+	keepSamples := currentFrameSamples + maxPreSpeechSamples
+	if keepSamples >= len(allData) {
+		return allData
+	}
+
+	audio := make([]float32, keepSamples)
+	copy(audio, allData[len(allData)-keepSamples:])
+	return audio
 }
 
 // getSpeakerResult 获取暂存的声纹结果（带超时）

--- a/internal/app/server/chat/asr_history_audio_test.go
+++ b/internal/app/server/chat/asr_history_audio_test.go
@@ -1,0 +1,47 @@
+package chat
+
+import "testing"
+
+func TestTrimFirstSpeechAudioKeepsCurrentFrameAndMaxPreSpeech(t *testing.T) {
+	allData := make([]float32, 1000)
+	for i := range allData {
+		allData[i] = float32(i)
+	}
+
+	got := trimFirstSpeechAudio(allData, 20, 1000, 1)
+
+	if len(got) != 220 {
+		t.Fatalf("len = %d, want 220", len(got))
+	}
+	if got[0] != 780 {
+		t.Fatalf("first sample = %v, want 780", got[0])
+	}
+	if got[len(got)-1] != 999 {
+		t.Fatalf("last sample = %v, want 999", got[len(got)-1])
+	}
+}
+
+func TestTrimFirstSpeechAudioKeepsShortBuffer(t *testing.T) {
+	allData := []float32{1, 2, 3, 4, 5}
+
+	got := trimFirstSpeechAudio(allData, 2, 1000, 1)
+
+	if len(got) != len(allData) {
+		t.Fatalf("len = %d, want %d", len(got), len(allData))
+	}
+	for i := range allData {
+		if got[i] != allData[i] {
+			t.Fatalf("sample[%d] = %v, want %v", i, got[i], allData[i])
+		}
+	}
+}
+
+func TestTrimFirstSpeechAudioInvalidFormatKeepsOriginal(t *testing.T) {
+	allData := []float32{1, 2, 3, 4, 5}
+
+	got := trimFirstSpeechAudio(allData, 2, 0, 1)
+
+	if len(got) != len(allData) {
+		t.Fatalf("len = %d, want %d", len(got), len(allData))
+	}
+}


### PR DESCRIPTION
## Summary
- Trim cached pre-speech audio to at most 200ms when local VAD first detects speech.
- Keep `auto_end=true` behavior unchanged and continue using the existing `HistoryAudioBuffer`.
- Add unit coverage for first-speech audio trimming boundaries.

## Tests
- `gofmt -w internal/app/server/chat/asr.go internal/app/server/chat/asr_history_audio_test.go`
- `git diff --check`
- `go test ./internal/app/server/chat -run TestTrimFirstSpeechAudio -count=1` (blocked locally: default CGO disabled causes opus/ten_vad build errors; enabling CGO fails because gcc is not installed)