### PR TITLE
fix: 优化智能体 ws mcp 端点保活

### DIFF
--- a/internal/domain/mcp/device_manager.go
+++ b/internal/domain/mcp/device_manager.go
@@ -21,6 +21,7 @@ const (
 	deviceMCPPingInterval          = 2 * time.Minute
 	wsEndpointToolsRefreshInterval = 10 * time.Minute
 	heartbeatRefreshFailureLimit   = 5
+	mcpConnectionOfflineTimeout    = 3 * deviceMCPPingInterval
 )
 
 // DeviceMcpSession 代表一个设备的MCP会话，聚合了多种MCP连接
@@ -454,7 +455,9 @@ func (dc *McpClientInstance) closeWithReason(reason string) {
 
 	dc.setConnected(false)
 	dc.setInitState(mcpClientInitStateIdle)
-	dc.cancel()
+	if dc.cancel != nil {
+		dc.cancel()
+	}
 	if dc.mcpClient != nil && reason != "connection_closed" && reason != "manual_close" {
 		if err := dc.mcpClient.Close(); err != nil {
 			logger.Warnf("关闭MCP客户端 %s transport 失败: %v", dc.serverName, err)
@@ -534,18 +537,18 @@ func (dc *DeviceMcpSession) heartbeatMcpInstance(mcpInstance *McpClientInstance)
 		logger.Debugf("设备 %s 通过 tools/list 心跳维持 IoT MCP 存活", mcpInstance.serverName)
 		return
 	}
-	if lastRefresh := mcpInstance.LastToolsRefresh(); lastRefresh.IsZero() || time.Since(lastRefresh) >= wsEndpointToolsRefreshInterval {
-		if err := mcpInstance.refreshTools(); err != nil {
-			dc.handleHeartbeatRefreshFailure(mcpInstance, err)
-			return
-		}
-	}
 	err := mcpInstance.mcpClient.Ping(mcpInstance.Ctx)
 	if err == nil {
 		mcpInstance.setLastPing(time.Now())
 		logger.Debugf("设备 %s ping成功", mcpInstance.serverName)
 	} else {
 		logger.Warnf("设备 %s ping失败: %v", mcpInstance.serverName, err)
+	}
+	if lastRefresh := mcpInstance.LastToolsRefresh(); lastRefresh.IsZero() || time.Since(lastRefresh) >= wsEndpointToolsRefreshInterval {
+		if err := mcpInstance.refreshTools(); err != nil {
+			dc.handleHeartbeatRefreshFailure(mcpInstance, err)
+			return
+		}
 	}
 }
 

--- a/internal/domain/mcp/mcp_pool.go
+++ b/internal/domain/mcp/mcp_pool.go
@@ -136,13 +136,14 @@ func (p *McpClientPool) checkOffline() {
 }
 
 func (p *McpClientPool) sweepOfflineClients() {
+	now := time.Now()
 	for _, client := range p.device2McpClient.Items() {
 		// 检查WebSocket端点MCP连接
 		hasActiveWsConnections := false
 		staleWsConnections := make([]*McpClientInstance, 0)
 		client.wsEndPointMcp.Range(func(_, value interface{}) bool {
 			wsInstance := value.(*McpClientInstance)
-			if time.Since(wsInstance.LastPing()) > 2*time.Minute {
+			if now.Sub(wsInstance.LastPing()) > mcpConnectionOfflineTimeout {
 				staleWsConnections = append(staleWsConnections, wsInstance)
 			} else {
 				hasActiveWsConnections = true
@@ -150,8 +151,7 @@ func (p *McpClientPool) sweepOfflineClients() {
 			return true //continue
 		})
 		for _, wsInstance := range staleWsConnections {
-			wsInstance.setConnected(false)
-			wsInstance.cancel()
+			wsInstance.closeWithReason("offline_timeout")
 		}
 
 		// 检查IoT over MCP连接（按 transportType）
@@ -159,7 +159,7 @@ func (p *McpClientPool) sweepOfflineClients() {
 		staleIotConnections := make([]*McpClientInstance, 0)
 		client.iotMux.Lock()
 		for transportType, iotClient := range client.iotOverMcpByTransport {
-			if time.Since(iotClient.LastPing()) > 2*time.Minute {
+			if now.Sub(iotClient.LastPing()) > mcpConnectionOfflineTimeout {
 				staleIotConnections = append(staleIotConnections, iotClient)
 				delete(client.iotOverMcpByTransport, transportType)
 			} else {
@@ -168,8 +168,7 @@ func (p *McpClientPool) sweepOfflineClients() {
 		}
 		client.iotMux.Unlock()
 		for _, iotClient := range staleIotConnections {
-			iotClient.setConnected(false)
-			iotClient.cancel()
+			iotClient.closeWithReason("offline_timeout")
 		}
 
 		// 如果没有任何活跃连接，移除客户端

--- a/internal/domain/mcp/mcp_test.go
+++ b/internal/domain/mcp/mcp_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
+	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,12 @@ func markTestClientConnected(client *McpClientInstance, lastPing time.Time) *Mcp
 	client.setConnected(true)
 	client.setLastPing(lastPing)
 	return client
+}
+
+func newTestMcpClientPool() *McpClientPool {
+	return &McpClientPool{
+		device2McpClient: cmap.New[*DeviceMcpSession](),
+	}
 }
 
 func TestGlobalMCPManager_Singleton(t *testing.T) {
@@ -1522,8 +1529,103 @@ func TestHeartbeatWsEndpointRuntimeRefreshesToolsAfterTenMinutesAndPings(t *test
 	assert.True(t, instance.LastPing().After(oldPing))
 	assert.True(t, instance.LastToolsRefresh().After(oldRefresh))
 	methods := transportInstance.drainRequestMethods()
-	assert.Contains(t, methods, string(mcp.MethodToolsList))
-	assert.Contains(t, methods, string(mcp.MethodPing))
+	assert.Equal(t, []string{string(mcp.MethodPing), string(mcp.MethodToolsList)}, methods)
+}
+
+func TestHeartbeatWsEndpointRuntimePingsBeforeToolsRefreshFailure(t *testing.T) {
+	transportInstance := &mockGlobalTransport{
+		listResponses: []mockGlobalTransportListResponse{
+			{err: fmt.Errorf("list tools failed")},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	instance := &McpClientInstance{
+		serverName: "ws_endpoint_mcp_test",
+		mcpClient:  client.NewClient(transportInstance),
+		Ctx:        ctx,
+		cancel:     cancel,
+	}
+	instance.storeToolsSnapshot(make(map[string]einotool.InvokableTool))
+	instance.setConnected(true)
+	require.NoError(t, instance.sendInitlize(context.Background()))
+
+	oldPing := time.Unix(100, 0)
+	oldRefresh := time.Now().Add(-11 * time.Minute)
+	instance.setLastPing(oldPing)
+	instance.setLastToolsRefresh(oldRefresh)
+
+	session := &DeviceMcpSession{}
+	transportInstance.drainRequestMethods()
+
+	session.heartbeatMcpInstance(instance)
+
+	assert.True(t, instance.LastPing().After(oldPing))
+	assert.EqualValues(t, 1, instance.RefreshFailureCount())
+	assert.True(t, instance.IsConnected())
+	assert.Equal(t, []string{string(mcp.MethodPing), string(mcp.MethodToolsList)}, transportInstance.drainRequestMethods())
+}
+
+func TestSweepOfflineClientsKeepsWsEndpointWithinOfflineTimeout(t *testing.T) {
+	pool := newTestMcpClientPool()
+	deviceID := fmt.Sprintf("ws-endpoint-offline-window-%d", time.Now().UnixNano())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clientCtx, clientCancel := context.WithCancel(ctx)
+	defer clientCancel()
+
+	session := &DeviceMcpSession{
+		deviceID:              deviceID,
+		Ctx:                   ctx,
+		cancel:                cancel,
+		iotOverMcpByTransport: make(map[string]*McpClientInstance),
+	}
+	instance := markTestClientConnected(&McpClientInstance{
+		serverName: "ws_endpoint_mcp_test",
+		Ctx:        clientCtx,
+		cancel:     clientCancel,
+	}, time.Now().Add(-(deviceMCPPingInterval + 30*time.Second)))
+	instance.SetOnCloseHandler(session.handleMcpClientClose)
+	session.wsEndPointMcp.Store(instance.serverName, instance)
+	pool.AddMcpClient(deviceID, session)
+
+	pool.sweepOfflineClients()
+
+	assert.True(t, instance.IsConnected())
+	assert.NoError(t, clientCtx.Err())
+	assert.NotNil(t, pool.GetMcpClient(deviceID))
+}
+
+func TestSweepOfflineClientsClosesWsEndpointAfterOfflineTimeout(t *testing.T) {
+	pool := newTestMcpClientPool()
+	deviceID := fmt.Sprintf("ws-endpoint-offline-timeout-%d", time.Now().UnixNano())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clientCtx, clientCancel := context.WithCancel(ctx)
+	defer clientCancel()
+
+	session := &DeviceMcpSession{
+		deviceID:              deviceID,
+		Ctx:                   ctx,
+		cancel:                cancel,
+		iotOverMcpByTransport: make(map[string]*McpClientInstance),
+	}
+	instance := markTestClientConnected(&McpClientInstance{
+		serverName: "ws_endpoint_mcp_test",
+		Ctx:        clientCtx,
+		cancel:     clientCancel,
+	}, time.Now().Add(-(mcpConnectionOfflineTimeout + time.Second)))
+	instance.SetOnCloseHandler(session.handleMcpClientClose)
+	session.wsEndPointMcp.Store(instance.serverName, instance)
+	pool.AddMcpClient(deviceID, session)
+
+	pool.sweepOfflineClients()
+
+	assert.False(t, instance.IsConnected())
+	assert.ErrorIs(t, clientCtx.Err(), context.Canceled)
+	assert.Nil(t, pool.GetMcpClient(deviceID))
 }
 
 func TestGetToolByNameWithTransport_PrefersCurrentTransport(t *testing.T) {

--- a/manager/backend/controllers/admin.go
+++ b/manager/backend/controllers/admin.go
@@ -2963,8 +2963,22 @@ func (ac *AdminController) GetAgentMCPEndpoint(c *gin.Context) {
 		return
 	}
 
-	// 返回单个endpoint字符串
-	c.JSON(http.StatusOK, gin.H{"data": gin.H{"endpoint": endpoint}})
+	data := newMcpEndpointData(endpoint)
+	if ac.WebSocketController == nil {
+		data["status_message"] = "websocket controller unavailable"
+		c.JSON(http.StatusOK, gin.H{"data": data})
+		return
+	}
+
+	statusResult, statusErr := ac.WebSocketController.RequestMcpEndpointStatusFromClient(context.Background(), agentID)
+	if statusErr != nil {
+		data["status_message"] = statusErr.Error()
+		c.JSON(http.StatusOK, gin.H{"data": data})
+		return
+	}
+
+	applyMcpEndpointStatus(data, statusResult)
+	c.JSON(http.StatusOK, gin.H{"data": data})
 }
 
 // GetAgentOpenClawEndpoint 获取智能体的OpenClaw接入点URL

--- a/manager/backend/controllers/admin_mcp_endpoint_test.go
+++ b/manager/backend/controllers/admin_mcp_endpoint_test.go
@@ -1,0 +1,71 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"xiaozhi/manager/backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestAdminGetAgentMCPEndpointIncludesRuntimeStatusFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := setupAgentDeviceServiceTestDB(t)
+	if err := db.Create(&models.Config{
+		Type:      "ota",
+		Name:      "ota-default",
+		ConfigID:  "ota-default",
+		IsDefault: true,
+		Enabled:   true,
+		JsonData:  `{"external":{"websocket":{"url":"wss://example.test/go_ws/xiaozhi/v1/"}}}`,
+	}).Error; err != nil {
+		t.Fatalf("create ota config: %v", err)
+	}
+
+	router := gin.New()
+	adminController := &AdminController{
+		DB:                db,
+		EndpointAuthToken: "test-endpoint-secret",
+	}
+	router.GET("/api/admin/agents/:id/mcp-endpoint", func(c *gin.Context) {
+		c.Set("user_id", uint(7))
+		adminController.GetAgentMCPEndpoint(c)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/admin/agents/42/mcp-endpoint", nil)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var payload struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	endpoint, _ := payload.Data["endpoint"].(string)
+	if !strings.HasPrefix(endpoint, "wss://example.test/mcp?token=") {
+		t.Fatalf("endpoint = %q, want wss://example.test/mcp?token=...", endpoint)
+	}
+	if payload.Data["status"] != "unknown" {
+		t.Fatalf("status = %#v, want unknown", payload.Data["status"])
+	}
+	if payload.Data["connected"] != false {
+		t.Fatalf("connected = %#v, want false", payload.Data["connected"])
+	}
+	if payload.Data["client_count"] != float64(0) {
+		t.Fatalf("client_count = %#v, want 0", payload.Data["client_count"])
+	}
+	if payload.Data["status_message"] != "websocket controller unavailable" {
+		t.Fatalf("status_message = %#v, want websocket controller unavailable", payload.Data["status_message"])
+	}
+}

--- a/manager/backend/controllers/common.go
+++ b/manager/backend/controllers/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -62,4 +63,43 @@ func GetAgentMcpToolsCommon(
 
 	log.Printf("成功获取MCP工具列表: count=%d", len(tools))
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"tools": tools}})
+}
+
+func newMcpEndpointData(endpoint string) gin.H {
+	return gin.H{
+		"endpoint":     endpoint,
+		"status":       "unknown",
+		"connected":    false,
+		"tools_count":  0,
+		"client_count": 0,
+	}
+}
+
+func applyMcpEndpointStatus(data gin.H, statusResult map[string]interface{}) {
+	if data == nil || statusResult == nil {
+		return
+	}
+
+	connected, _ := statusResult["connected"].(bool)
+	status, _ := statusResult["status"].(string)
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" {
+		if connected {
+			status = "online"
+		} else {
+			status = "offline"
+		}
+	}
+
+	data["connected"] = connected
+	data["status"] = status
+	if clientCount, ok := statusResult["client_count"]; ok {
+		data["client_count"] = clientCount
+	}
+	if toolsCount, ok := statusResult["tools_count"]; ok {
+		data["tools_count"] = toolsCount
+	}
+	if statusMessage, ok := statusResult["status_message"].(string); ok && strings.TrimSpace(statusMessage) != "" {
+		data["status_message"] = statusMessage
+	}
 }

--- a/manager/backend/controllers/user.go
+++ b/manager/backend/controllers/user.go
@@ -655,12 +655,7 @@ func (uc *UserController) GetAgentMCPEndpoint(c *gin.Context) {
 		return
 	}
 
-	data := gin.H{
-		"endpoint":    endpoint,
-		"status":      "unknown",
-		"connected":   false,
-		"tools_count": 0,
-	}
+	data := newMcpEndpointData(endpoint)
 	if uc.WebSocketController == nil {
 		data["status_message"] = "websocket controller unavailable"
 		c.JSON(http.StatusOK, gin.H{"data": data})
@@ -674,22 +669,7 @@ func (uc *UserController) GetAgentMCPEndpoint(c *gin.Context) {
 		return
 	}
 
-	connected, _ := statusResult["connected"].(bool)
-	status, _ := statusResult["status"].(string)
-	status = strings.ToLower(strings.TrimSpace(status))
-	if status == "" {
-		if connected {
-			status = "online"
-		} else {
-			status = "offline"
-		}
-	}
-
-	data["connected"] = connected
-	data["status"] = status
-	if clientCount, ok := statusResult["client_count"]; ok {
-		data["client_count"] = clientCount
-	}
+	applyMcpEndpointStatus(data, statusResult)
 	c.JSON(http.StatusOK, gin.H{"data": data})
 }
 

--- a/test/auto_test/TEST_CASE_COVERAGE.md
+++ b/test/auto_test/TEST_CASE_COVERAGE.md
@@ -71,6 +71,8 @@ CGO_LDFLAGS="-lm" go run -buildvcs=false -tags nolibopusfile ./test/auto_test \
 | `mcp_initialize` | WebSocket hello，声明 `features.mcp=true` | 收到 MCP `initialize` 和 `tools/list`；客户端 result id 匹配请求 id |
 | `hello_without_mcp_no_initialize` | WebSocket hello，不声明 MCP feature | hello 成功；负向窗口内无 MCP `initialize/tools/list` |
 | `mcp_duplicate_hello_no_reinitialize` | 启用 MCP 的 WebSocket hello；MCP 初始化完成后再次 hello | hello ack 数量为 2；MCP 初始化只发生 1 次 |
+| `agent_ws_endpoint_mcp` | 智能体 MCP server 通过 `/mcp?token=...` 反连主程序 | endpoint 鉴权成功；主程序下发 MCP `initialize` 和 `tools/list`；短时保活不掉线 |
+| `agent_ws_endpoint_mcp_keepalive` | 智能体 MCP server 反连后持续挂机，跨过 2 分钟离线窗口和 10 分钟工具刷新边界 | 收到主程序 JSON-RPC `ping`；10 分钟后再次收到 `tools/list`；连接未断开。该用例为显式选择用例，不包含在 `all` 中 |
 | `abort_after_listen_start` | WebSocket hello；`listen start manual`；发送 `abort` | abort 发送成功；控制链路不报错 |
 | `abort_during_tts` | WebSocket hello；manual 语音对话；TTS 开始后发送 `abort` | 已收到 STT/TTS；abort 后观察到 `tts stop` |
 | `realtime_interrupt` | WebSocket realtime 首轮语音触发 TTS；TTS 期间发送第二轮语音 | 第二轮 STT 成功；TTS stop/切换行为可观察 |
@@ -231,6 +233,31 @@ CGO_LDFLAGS="-lm" go run -buildvcs=false -tags nolibopusfile ./test/auto_test \
   - 首次 hello 触发一次完整 MCP 初始化
   - 第二次 hello 成功
   - duplicate hello 后不会重复收到 `initialize/tools/list`
+
+#### `agent_ws_endpoint_mcp`
+- 覆盖场景：智能体 WebSocket MCP endpoint 反连主程序 `/mcp?token=...`。
+- 测试流程：
+  - 根据 `-server` 的 host 派生 `ws(s)://host/mcp?token=...`
+  - 使用 `-endpoint_auth_token` 生成 `purpose=mcp-endpoint`、包含 `agentId` 的 HS256 JWT
+  - 在 auto_test 进程内启动一个 MCP server，提供 `hello_world` 与 `query_weather`
+  - MCP server 作为 WebSocket client 连接主程序 endpoint
+- 核心校验：
+  - endpoint 连接建立且 token 鉴权通过
+  - 主程序下发 MCP `initialize`
+  - 主程序下发 MCP `tools/list`
+  - auto_test MCP server 正确回传 result
+  - 初始连接短时保持稳定，不立即断开
+
+#### `agent_ws_endpoint_mcp_keepalive`
+- 覆盖场景：用户反馈的“智能体 WebSocket MCP endpoint 一段时间后断连”回归链路。
+- 测试流程：
+  - 复用 `agent_ws_endpoint_mcp` 的连接方式
+  - 持续保持连接，等待主程序心跳和工具刷新周期
+  - 该用例耗时较长，默认不包含在 `-cases all`，需要显式指定
+- 核心校验：
+  - 超过 2 分钟离线判定窗口后仍能收到主程序 JSON-RPC `ping`
+  - 跨过 10 分钟工具刷新边界后再次收到 `tools/list`
+  - 过程中连接未断开
 
 ---
 
@@ -533,6 +560,7 @@ CGO_LDFLAGS="-lm" go run -buildvcs=false -tags nolibopusfile ./test/auto_test \
 - realtime stop/start 恢复识别校验
 - MCP `initialize` / `tools/list` 次数校验
 - MCP `result` 与请求 `id` 匹配校验
+- 智能体 WebSocket MCP endpoint 反连、JWT 鉴权、JSON-RPC `ping` 保活、周期性 `tools/list` 刷新校验
 - iot `success` 响应校验
 - abort 已发送校验
 - abort 后出现 `tts stop` 校验
@@ -566,6 +594,30 @@ CGO_LDFLAGS="-lm" go run -buildvcs=false -tags nolibopusfile ./test/auto_test \
   -device ws-regression-device \
   -cases auto1_roundtrip,auto2_roundtrip,realtime_roundtrip,injected_message_skip_llm,realtime_interrupt,realtime_duplicate_start_ignored \
   -case_timeout 80s
+```
+
+### 智能体 WebSocket MCP Endpoint 回归
+
+适合改动 `/mcp` endpoint、MCP session、工具列表刷新、状态管理、离线判定、重连/保活策略后运行：
+
+```bash
+CGO_LDFLAGS="-lm" go run -buildvcs=false -tags nolibopusfile ./test/auto_test \
+  -runner auto \
+  -server ws://localhost:9990/xiaozhi/v1/ \
+  -device smoke-agent \
+  -cases agent_ws_endpoint_mcp \
+  -endpoint_auth_token xiaozhi_mcp_openclaw_secret_key
+```
+
+长连接保活与 10 分钟工具刷新边界回归：
+
+```bash
+CGO_LDFLAGS="-lm" go run -buildvcs=false -tags nolibopusfile ./test/auto_test \
+  -runner auto \
+  -server ws://localhost:9990/xiaozhi/v1/ \
+  -device smoke-agent \
+  -cases agent_ws_endpoint_mcp_keepalive \
+  -endpoint_auth_token xiaozhi_mcp_openclaw_secret_key
 ```
 
 ### MQTT / UDP 主链路

--- a/test/auto_test/agent_ws_endpoint_mcp.go
+++ b/test/auto_test/agent_ws_endpoint_mcp.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	neturl "net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/gorilla/websocket"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const defaultAgentEndpointAuthToken = "xiaozhi_mcp_openclaw_secret_key"
+
+var agentEndpointAuthToken = defaultAgentEndpointAuthToken
+
+type agentWsEndpointRuntime struct {
+	conn   *websocket.Conn
+	server *server.MCPServer
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	writeMu sync.Mutex
+	stateMu sync.Mutex
+	methods map[string]int
+	results map[string]int
+	lastErr error
+}
+
+func runAgentWsEndpointMCPCase(serverAddr, deviceID string, testCase *protocolTestCase) error {
+	agentID := buildAgentWsEndpointAgentID(deviceID, testCase.Name)
+	endpoint, err := buildAgentWsEndpointURL(serverAddr, agentID)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("智能体 MCP endpoint: %s\n", endpoint)
+
+	runtime, err := startAgentWsEndpointRuntime(endpoint)
+	if err != nil {
+		return err
+	}
+	defer runtime.Close()
+
+	timeout := testCase.Timeout
+	if timeout <= 0 {
+		timeout = autoCaseTimeout
+	}
+	if err := runtime.waitForMethodCount("initialize", 1, timeout); err != nil {
+		return err
+	}
+	if err := runtime.waitForMethodCount("tools/list", 1, timeout); err != nil {
+		return err
+	}
+	if err := runtime.waitForResultCount("initialize", 1, timeout); err != nil {
+		return err
+	}
+	if err := runtime.waitForResultCount("tools/list", 1, timeout); err != nil {
+		return err
+	}
+
+	switch testCase.Kind {
+	case protocolCaseAgentWsEndpointKeepalive:
+		if err := runtime.waitForMethodCount("ping", 1, timeout); err != nil {
+			return err
+		}
+		if err := runtime.waitForMethodCount("tools/list", 2, timeout); err != nil {
+			return err
+		}
+		if err := runtime.waitForResultCount("tools/list", 2, timeout); err != nil {
+			return err
+		}
+	default:
+		if err := runtime.waitForStableConnection(2 * time.Second); err != nil {
+			return err
+		}
+	}
+
+	return runtime.err()
+}
+
+func startAgentWsEndpointRuntime(endpoint string) (*agentWsEndpointRuntime, error) {
+	conn, _, err := websocket.DefaultDialer.Dial(endpoint, http.Header{})
+	if err != nil {
+		return nil, fmt.Errorf("连接智能体 MCP endpoint 失败: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runtime := &agentWsEndpointRuntime{
+		conn:    conn,
+		server:  newAgentWsEndpointMCPServer(),
+		ctx:     ctx,
+		cancel:  cancel,
+		methods: make(map[string]int),
+		results: make(map[string]int),
+	}
+	runtime.start()
+	return runtime, nil
+}
+
+func newAgentWsEndpointMCPServer() *server.MCPServer {
+	mcpServer := server.NewMCPServer("auto_test_agent_ws_endpoint", "1.0.0")
+
+	helloTool := mcp.NewTool("hello_world",
+		mcp.WithDescription("Say hello to someone"),
+		mcp.WithString("name",
+			mcp.Required(),
+			mcp.Description("Name of the person to greet"),
+		),
+	)
+	weatherTool := mcp.NewTool("query_weather",
+		mcp.WithDescription("查询天气"),
+	)
+
+	mcpServer.AddTool(helloTool, agentWsEndpointHelloHandler)
+	mcpServer.AddTool(weatherTool, agentWsEndpointWeatherHandler)
+	return mcpServer
+}
+
+func (r *agentWsEndpointRuntime) start() {
+	r.wg.Add(2)
+	go r.readLoop()
+	go r.websocketPingLoop()
+}
+
+func (r *agentWsEndpointRuntime) readLoop() {
+	defer r.wg.Done()
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		default:
+		}
+
+		_, message, err := r.conn.ReadMessage()
+		if err != nil {
+			if r.ctx.Err() == nil {
+				r.setErr(fmt.Errorf("读取智能体 MCP endpoint 消息失败: %w", err))
+				r.cancel()
+			}
+			return
+		}
+
+		method := r.recordJSONRPCMethod(message)
+		response := r.server.HandleMessage(r.ctx, message)
+		if response == nil {
+			continue
+		}
+
+		responseBytes, err := json.Marshal(response)
+		if err != nil {
+			r.setErr(fmt.Errorf("序列化 MCP 响应失败: %w", err))
+			r.cancel()
+			return
+		}
+		if err := r.writeMessage(websocket.TextMessage, responseBytes); err != nil {
+			r.setErr(fmt.Errorf("发送 MCP 响应失败: %w", err))
+			r.cancel()
+			return
+		}
+		r.recordResult(method)
+	}
+}
+
+func (r *agentWsEndpointRuntime) websocketPingLoop() {
+	defer r.wg.Done()
+	ticker := time.NewTicker(20 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := r.writeMessage(websocket.PingMessage, []byte{}); err != nil {
+				r.setErr(fmt.Errorf("发送 websocket ping 失败: %w", err))
+				r.cancel()
+				return
+			}
+		}
+	}
+}
+
+func (r *agentWsEndpointRuntime) writeMessage(messageType int, payload []byte) error {
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
+	return r.conn.WriteMessage(messageType, payload)
+}
+
+func (r *agentWsEndpointRuntime) recordJSONRPCMethod(message []byte) string {
+	var request struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(message, &request); err != nil || strings.TrimSpace(request.Method) == "" {
+		return ""
+	}
+
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	r.methods[request.Method]++
+	return request.Method
+}
+
+func (r *agentWsEndpointRuntime) recordResult(method string) {
+	method = strings.TrimSpace(method)
+	if method == "" {
+		return
+	}
+
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	r.results[method]++
+}
+
+func (r *agentWsEndpointRuntime) waitForMethodCount(method string, expected int, timeout time.Duration) error {
+	return r.waitForCount("MCP endpoint 方法", method, expected, timeout, r.methodCount)
+}
+
+func (r *agentWsEndpointRuntime) waitForResultCount(method string, expected int, timeout time.Duration) error {
+	return r.waitForCount("MCP endpoint result", method, expected, timeout, r.resultCount)
+}
+
+func (r *agentWsEndpointRuntime) waitForCount(label string, method string, expected int, timeout time.Duration, countFunc func(string) int) error {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if countFunc(method) >= expected {
+			return nil
+		}
+		if err := r.err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("等待 %s %s 数量达到 %d 超时，当前=%d", label, method, expected, countFunc(method))
+		}
+
+		<-ticker.C
+	}
+}
+
+func (r *agentWsEndpointRuntime) waitForStableConnection(duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			return r.err()
+		case <-ticker.C:
+			if err := r.err(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (r *agentWsEndpointRuntime) methodCount(method string) int {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	return r.methods[method]
+}
+
+func (r *agentWsEndpointRuntime) resultCount(method string) int {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	return r.results[method]
+}
+
+func (r *agentWsEndpointRuntime) setErr(err error) {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	if r.lastErr == nil {
+		r.lastErr = err
+	}
+}
+
+func (r *agentWsEndpointRuntime) err() error {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	return r.lastErr
+}
+
+func (r *agentWsEndpointRuntime) Close() {
+	r.cancel()
+	_ = r.conn.Close()
+	r.wg.Wait()
+}
+
+func buildAgentWsEndpointURL(serverAddr, agentID string) (string, error) {
+	parsed, err := neturl.Parse(strings.TrimSpace(serverAddr))
+	if err != nil {
+		return "", fmt.Errorf("解析 server 地址失败: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("server 地址必须包含 scheme 和 host: %s", serverAddr)
+	}
+
+	switch parsed.Scheme {
+	case "http":
+		parsed.Scheme = "ws"
+	case "https":
+		parsed.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		return "", fmt.Errorf("不支持的 server scheme: %s", parsed.Scheme)
+	}
+
+	token, err := signAgentWsEndpointToken(agentID)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = "/mcp"
+	parsed.RawQuery = neturl.Values{"token": []string{token}}.Encode()
+	return parsed.String(), nil
+}
+
+func signAgentWsEndpointToken(agentID string) (string, error) {
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"userId":     1,
+		"agentId":    agentID,
+		"endpointId": "agent_" + agentID,
+		"purpose":    "mcp-endpoint",
+		"iat":        now.Unix(),
+		"exp":        now.Add(2 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	secret := strings.TrimSpace(agentEndpointAuthToken)
+	if secret == "" {
+		secret = defaultAgentEndpointAuthToken
+	}
+	return token.SignedString([]byte(secret))
+}
+
+func buildAgentWsEndpointAgentID(deviceID, caseName string) string {
+	base := strings.TrimSpace(deviceID)
+	if base == "" {
+		base = "auto-test"
+	}
+	return sanitizeCaseDeviceID(base+"-"+caseName, 72)
+}
+
+func agentWsEndpointHelloHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := request.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("Hello, %s!", name)), nil
+}
+
+func agentWsEndpointWeatherHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultText("天气晴朗 20度 北风3级"), nil
+}

--- a/test/auto_test/automation_suite.go
+++ b/test/auto_test/automation_suite.go
@@ -19,30 +19,32 @@ const defaultHelloTimeout = 10 * time.Second
 const defaultNegativeReadTimeout = 2 * time.Second
 
 const (
-	protocolCaseNormal                 = "normal"
-	protocolCaseMCP                    = "mcp"
-	protocolCaseInvalidHello           = "invalid_hello"
-	protocolCaseAbort                  = "abort"
-	protocolCaseHelloMetadata          = "hello_metadata"
-	protocolCaseInjectedMessage        = "injected_message"
-	protocolCaseIot                    = "iot"
-	protocolCaseTTSSentenceBoundaries  = "tts_sentence_boundaries"
-	protocolCaseRealtimeInterrupt      = "realtime_interrupt"
-	protocolCaseDuplicateHello         = "duplicate_hello"
-	protocolCaseListenBeforeHello      = "listen_before_hello"
-	protocolCaseAbortDuringTTS         = "abort_during_tts"
-	protocolCaseRealtimeListenStop     = "realtime_listen_stop"
-	protocolCaseNoMCP                  = "no_mcp"
-	protocolCaseMCPDuplicateHello      = "mcp_duplicate_hello"
-	protocolCaseRealtimeDuplicateStart = "realtime_duplicate_start"
-	protocolCaseGoodbyeThenResume      = "goodbye_then_resume"
-	protocolCaseOTAMetadata            = "ota_metadata"
-	protocolCaseOTAInvalidAlgorithm    = "ota_invalid_algorithm"
-	protocolCaseOTAInvalidChallenge    = "ota_invalid_challenge"
-	protocolCaseMqttUDPHello           = "mqtt_udp_hello"
-	protocolCaseMqttUDPInjectedMessage = "mqtt_udp_injected_message"
-	protocolCaseInjectedMessageAuto    = "injected_message_auto"
-	protocolCaseInjectedMessageCold    = "injected_message_cold"
+	protocolCaseNormal                   = "normal"
+	protocolCaseMCP                      = "mcp"
+	protocolCaseInvalidHello             = "invalid_hello"
+	protocolCaseAbort                    = "abort"
+	protocolCaseHelloMetadata            = "hello_metadata"
+	protocolCaseInjectedMessage          = "injected_message"
+	protocolCaseIot                      = "iot"
+	protocolCaseTTSSentenceBoundaries    = "tts_sentence_boundaries"
+	protocolCaseRealtimeInterrupt        = "realtime_interrupt"
+	protocolCaseDuplicateHello           = "duplicate_hello"
+	protocolCaseListenBeforeHello        = "listen_before_hello"
+	protocolCaseAbortDuringTTS           = "abort_during_tts"
+	protocolCaseRealtimeListenStop       = "realtime_listen_stop"
+	protocolCaseNoMCP                    = "no_mcp"
+	protocolCaseMCPDuplicateHello        = "mcp_duplicate_hello"
+	protocolCaseRealtimeDuplicateStart   = "realtime_duplicate_start"
+	protocolCaseGoodbyeThenResume        = "goodbye_then_resume"
+	protocolCaseOTAMetadata              = "ota_metadata"
+	protocolCaseOTAInvalidAlgorithm      = "ota_invalid_algorithm"
+	protocolCaseOTAInvalidChallenge      = "ota_invalid_challenge"
+	protocolCaseMqttUDPHello             = "mqtt_udp_hello"
+	protocolCaseMqttUDPInjectedMessage   = "mqtt_udp_injected_message"
+	protocolCaseInjectedMessageAuto      = "injected_message_auto"
+	protocolCaseInjectedMessageCold      = "injected_message_cold"
+	protocolCaseAgentWsEndpointMCP       = "agent_ws_endpoint_mcp"
+	protocolCaseAgentWsEndpointKeepalive = "agent_ws_endpoint_mcp_keepalive"
 )
 
 var (
@@ -126,6 +128,7 @@ type protocolTestCase struct {
 	ExpectIotSuccess           bool
 	ExpectSentenceEnd          bool
 	ExpectNoServerGoodbye      bool
+	ExplicitOnly               bool
 }
 
 type protocolTestResult struct {
@@ -691,6 +694,21 @@ func buildProtocolTestCases() []protocolTestCase {
 			ExpectMCPResponse:        true,
 		},
 		{
+			Name:        "agent_ws_endpoint_mcp",
+			Description: "验证智能体 WebSocket MCP endpoint 反连、initialize/tools/list 与短时保活",
+			Kind:        protocolCaseAgentWsEndpointMCP,
+			LocalMode:   LocalModeManual,
+			Timeout:     autoCaseTimeout,
+		},
+		{
+			Name:         "agent_ws_endpoint_mcp_keepalive",
+			Description:  "验证智能体 WebSocket MCP endpoint 超过 2 分钟离线窗口与 10 分钟工具刷新边界后仍在线",
+			Kind:         protocolCaseAgentWsEndpointKeepalive,
+			LocalMode:    LocalModeManual,
+			Timeout:      13 * time.Minute,
+			ExplicitOnly: true,
+		},
+		{
 			Name:             "duplicate_hello_rehandshake",
 			Description:      "验证 websocket duplicate hello 后仍可继续正常 listen/stt/tts",
 			Kind:             protocolCaseDuplicateHello,
@@ -927,7 +945,13 @@ func sanitizeDeviceIDSuffix(input string) string {
 func selectProtocolTestCases() ([]protocolTestCase, error) {
 	allCases := buildProtocolTestCases()
 	if strings.EqualFold(strings.TrimSpace(autoCasesFilter), "all") || strings.TrimSpace(autoCasesFilter) == "" {
-		return allCases, nil
+		selected := make([]protocolTestCase, 0, len(allCases))
+		for _, testCase := range allCases {
+			if !testCase.ExplicitOnly {
+				selected = append(selected, testCase)
+			}
+		}
+		return selected, nil
 	}
 
 	lookup := make(map[string]protocolTestCase, len(allCases))
@@ -1049,6 +1073,8 @@ func runProtocolCase(serverAddr, deviceID, audioFile string, testCase *protocolT
 		return runMqttUDPHelloCase(serverAddr, deviceID, testCase)
 	case protocolCaseMqttUDPInjectedMessage:
 		return runMqttUDPInjectedMessageCase(serverAddr, deviceID, testCase)
+	case protocolCaseAgentWsEndpointMCP, protocolCaseAgentWsEndpointKeepalive:
+		return runAgentWsEndpointMCPCase(serverAddr, deviceID, testCase)
 	default:
 		return runClient(serverAddr, deviceID, audioFile, testCase)
 	}

--- a/test/auto_test/xiaozhi_websocket_client.go
+++ b/test/auto_test/xiaozhi_websocket_client.go
@@ -187,13 +187,14 @@ func main() {
 	text := flag.String("text", "你好测试", "文本")
 	runnerFlag := flag.String("runner", "manual", "运行方式(manual|auto)")
 	modeFlag := flag.String("mode", LocalModeAuto1, "本地模式(auto1|auto2|manual|realtime，auto会映射到auto1)")
-	casesFlag := flag.String("cases", "all", "自动化测试用例(all|manual_roundtrip,auto1_roundtrip,auto2_roundtrip,realtime_roundtrip,hello_metadata,injected_message_skip_llm,iot_roundtrip,tts_sentence_boundaries,manual_multi_turn,mcp_initialize,hello_without_mcp_no_initialize,mcp_duplicate_hello_no_reinitialize,invalid_hello_missing_audio_params,invalid_hello_unsupported_transport,duplicate_hello_rehandshake,listen_before_hello_ignored,abort_after_listen_start,abort_during_tts,realtime_interrupt,realtime_listen_stop,realtime_duplicate_start_ignored,goodbye_then_resume,ota_metadata,ota_activate_invalid_algorithm,ota_activate_invalid_challenge_if_required,mqtt_udp_hello,mqtt_udp_injected_message)")
+	casesFlag := flag.String("cases", "all", "自动化测试用例(all|manual_roundtrip,auto1_roundtrip,auto2_roundtrip,realtime_roundtrip,hello_metadata,injected_message_skip_llm,iot_roundtrip,tts_sentence_boundaries,manual_multi_turn,mcp_initialize,hello_without_mcp_no_initialize,mcp_duplicate_hello_no_reinitialize,agent_ws_endpoint_mcp,agent_ws_endpoint_mcp_keepalive,invalid_hello_missing_audio_params,invalid_hello_unsupported_transport,duplicate_hello_rehandshake,listen_before_hello_ignored,abort_after_listen_start,abort_during_tts,realtime_interrupt,realtime_listen_stop,realtime_duplicate_start_ignored,goodbye_then_resume,ota_metadata,ota_activate_invalid_algorithm,ota_activate_invalid_challenge_if_required,mqtt_udp_hello,mqtt_udp_injected_message)")
 	caseTimeoutFlag := flag.Duration("case_timeout", 20*time.Second, "自动化单用例超时时间")
 	turnsFlag := flag.Int("turns", 1, "自动化测试每个用例发言轮次")
 	ttsProviderFlag := flag.String("tts_provider", "edge_offline", "TTS provider (edge_offline|edge|cosyvoice)")
 	sampleRate := flag.Int("sample_rate", 16000, "sampleRate")
 	frameDurationsMs := flag.Int("frame_ms", 20, "frame duration ms")
 	addMcpFlag := flag.Bool("mcp", false, "是否启用mcp")
+	endpointAuthTokenFlag := flag.String("endpoint_auth_token", defaultAgentEndpointAuthToken, "智能体 WebSocket MCP endpoint JWT 签名密钥")
 
 	flag.Parse()
 
@@ -214,6 +215,7 @@ func main() {
 	autoTurns = *turnsFlag
 	ttsProviderName = strings.TrimSpace(*ttsProviderFlag)
 	addMcp = *addMcpFlag
+	agentEndpointAuthToken = strings.TrimSpace(*endpointAuthTokenFlag)
 
 	if strings.TrimSpace(*modeFlag) != mode {
 		fmt.Printf("本地模式 %s 已映射为 %s\n", strings.TrimSpace(*modeFlag), mode)


### PR DESCRIPTION
## 变更内容
- 优化智能体 WebSocket MCP endpoint 心跳顺序，先 ping 再刷新工具列表，避免 tools/list 抖动导致 LastPing 空窗
- 放宽 MCP 连接离线判定窗口，并统一 offline_timeout 关闭路径
- 补充 manager 管理端 MCP endpoint 运行态字段
- 新增 auto_test 覆盖真实 /mcp endpoint 反连和长连接保活场景

## 验证
- go test ./internal/domain/mcp
- cd manager/backend && go test ./controllers
- cd manager/backend && go test ./...