### PR TITLE
兼容 Silero VAD 模型路径

### DIFF
--- a/internal/domain/vad/silero_vad/vad.go
+++ b/internal/domain/vad/silero_vad/vad.go
@@ -3,8 +3,10 @@ package silero_vad
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	. "xiaozhi-esp32-server-golang/internal/domain/vad/inter"
@@ -22,6 +24,11 @@ var defaultVADConfig = map[string]interface{}{
 	"intra_op_num_threads":    1,
 	"inter_op_num_threads":    1,
 }
+
+const (
+	sourceSileroVADModelPath  = "config/models/vad/silero_vad.onnx"
+	releaseSileroVADModelPath = "models/vad/silero_vad.onnx"
+)
 
 type runtimeKey struct {
 	modelPath         string
@@ -66,6 +73,11 @@ func NewSileroVAD(config map[string]interface{}) (*SileroVAD, error) {
 	if modelPath == "" {
 		return nil, errors.New("缺少模型路径配置")
 	}
+	resolvedModelPath, err := resolveModelPath(modelPath)
+	if err != nil {
+		return nil, err
+	}
+	modelPath = resolvedModelPath
 
 	threshold := getFloat32(cfg, "threshold", 0.5)
 	silenceMs := getDurationMs(cfg, "min_silence_duration_ms", "min_silence_duration", 100)
@@ -302,6 +314,80 @@ func releaseRuntime(key runtimeKey) error {
 	runtimeMu.Unlock()
 
 	return shared.runtime.Destroy()
+}
+
+func resolveModelPath(modelPath string) (string, error) {
+	modelPath = strings.TrimSpace(modelPath)
+	if modelPath == "" {
+		return "", errors.New("缺少模型路径配置")
+	}
+
+	candidates := buildModelPathCandidates(modelPath, modelPathSearchRoots()...)
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("模型文件不存在: %s (已尝试: %s)", modelPath, strings.Join(candidates, ", "))
+}
+
+func buildModelPathCandidates(modelPath string, roots ...string) []string {
+	modelPath = strings.TrimSpace(modelPath)
+	if modelPath == "" {
+		return nil
+	}
+
+	cleanedPath := filepath.Clean(filepath.FromSlash(modelPath))
+	if filepath.IsAbs(cleanedPath) {
+		return []string{cleanedPath}
+	}
+
+	variants := []string{cleanedPath}
+	switch cleanedPath {
+	case filepath.Clean(filepath.FromSlash(sourceSileroVADModelPath)):
+		variants = append(variants, filepath.Clean(filepath.FromSlash(releaseSileroVADModelPath)))
+	case filepath.Clean(filepath.FromSlash(releaseSileroVADModelPath)):
+		variants = append(variants, filepath.Clean(filepath.FromSlash(sourceSileroVADModelPath)))
+	}
+
+	if len(roots) == 0 {
+		roots = []string{""}
+	}
+
+	seen := make(map[string]struct{})
+	candidates := make([]string, 0, len(roots)*len(variants))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		for _, variant := range variants {
+			candidate := variant
+			if root != "" {
+				candidate = filepath.Join(root, variant)
+			}
+			candidate = filepath.Clean(candidate)
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func modelPathSearchRoots() []string {
+	roots := make([]string, 0, 2)
+	if cwd, err := os.Getwd(); err == nil && cwd != "" {
+		roots = append(roots, cwd)
+	}
+	if executablePath, err := os.Executable(); err == nil && executablePath != "" {
+		roots = append(roots, filepath.Dir(executablePath))
+	}
+	if len(roots) == 0 {
+		roots = append(roots, "")
+	}
+	return roots
 }
 
 func withDefaults(config map[string]interface{}) map[string]interface{} {

--- a/internal/domain/vad/silero_vad/vad_test.go
+++ b/internal/domain/vad/silero_vad/vad_test.go
@@ -1,7 +1,10 @@
 package silero_vad
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -39,5 +42,120 @@ func TestResolveNumSessionsFallsBackToCPUCountForInvalidValue(t *testing.T) {
 	want := runtime.NumCPU()
 	if got != want {
 		t.Fatalf("resolveNumSessions() = %d, want %d", got, want)
+	}
+}
+
+func TestBuildModelPathCandidatesAddsSourceToReleaseFallback(t *testing.T) {
+	root := "app"
+	got := buildModelPathCandidates("config/models/vad/silero_vad.onnx", root)
+	want := []string{
+		filepath.Join(root, "config", "models", "vad", "silero_vad.onnx"),
+		filepath.Join(root, "models", "vad", "silero_vad.onnx"),
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("buildModelPathCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildModelPathCandidatesAddsReleaseToSourceFallback(t *testing.T) {
+	root := "app"
+	got := buildModelPathCandidates("models/vad/silero_vad.onnx", root)
+	want := []string{
+		filepath.Join(root, "models", "vad", "silero_vad.onnx"),
+		filepath.Join(root, "config", "models", "vad", "silero_vad.onnx"),
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("buildModelPathCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveModelPathPrefersConfiguredPathWhenPresent(t *testing.T) {
+	root := t.TempDir()
+	runInDir(t, root)
+	writeTestFile(t, filepath.Join(root, "config", "models", "vad", "silero_vad.onnx"))
+	writeTestFile(t, filepath.Join(root, "models", "vad", "silero_vad.onnx"))
+
+	got, err := resolveModelPath("config/models/vad/silero_vad.onnx")
+	if err != nil {
+		t.Fatalf("resolveModelPath() error = %v", err)
+	}
+	want := filepath.Join(root, "config", "models", "vad", "silero_vad.onnx")
+	if got != want {
+		t.Fatalf("resolveModelPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveModelPathFallsBackFromSourceLayoutToReleaseLayout(t *testing.T) {
+	root := t.TempDir()
+	runInDir(t, root)
+	writeTestFile(t, filepath.Join(root, "models", "vad", "silero_vad.onnx"))
+
+	got, err := resolveModelPath("config/models/vad/silero_vad.onnx")
+	if err != nil {
+		t.Fatalf("resolveModelPath() error = %v", err)
+	}
+	want := filepath.Join(root, "models", "vad", "silero_vad.onnx")
+	if got != want {
+		t.Fatalf("resolveModelPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveModelPathFallsBackFromReleaseLayoutToSourceLayout(t *testing.T) {
+	root := t.TempDir()
+	runInDir(t, root)
+	writeTestFile(t, filepath.Join(root, "config", "models", "vad", "silero_vad.onnx"))
+
+	got, err := resolveModelPath("models/vad/silero_vad.onnx")
+	if err != nil {
+		t.Fatalf("resolveModelPath() error = %v", err)
+	}
+	want := filepath.Join(root, "config", "models", "vad", "silero_vad.onnx")
+	if got != want {
+		t.Fatalf("resolveModelPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveModelPathReportsTriedCandidates(t *testing.T) {
+	root := t.TempDir()
+	runInDir(t, root)
+
+	_, err := resolveModelPath("config/models/vad/silero_vad.onnx")
+	if err == nil {
+		t.Fatal("resolveModelPath() error = nil, want missing file error")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		filepath.Join(root, "config", "models", "vad", "silero_vad.onnx"),
+		filepath.Join(root, "models", "vad", "silero_vad.onnx"),
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("resolveModelPath() error = %q, want it to include %q", message, want)
+		}
+	}
+}
+
+func runInDir(t *testing.T, dir string) {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("os.Chdir(%q) error = %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatalf("restore cwd to %q error = %v", previous, err)
+		}
+	})
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Silero VAD 加载模型前解析相对路径，兼容源码目录 config/models/vad/silero_vad.onnx 与 AIO release 目录 models/vad/silero_vad.onnx。
- 保留用户配置优先级，缺失时在当前工作目录和可执行文件目录下尝试 fallback。
- 添加单元测试覆盖两种目录结构和缺失文件错误提示。

## Test Plan
- /usr/local/go/bin/go test -count=1 ./internal/domain/vad ./internal/domain/vad/inter ./internal/domain/vad/silero_vad ./internal/domain/vad/ten_vad