### PR TITLE
优化 ASR 噪声过滤与 VAD 双阈值判断

### DIFF
--- a/build/common/main_config.yaml
+++ b/build/common/main_config.yaml
@@ -110,6 +110,7 @@ vad:
   silero_vad:
     model_path: "models/vad/silero_vad.onnx"  # 模型文件路径
     threshold: 0.5                    # 检测阈值
+    threshold_low: 0.35               # 退出语音阈值，低于该值切换为静音；介于 threshold_low 和 threshold 之间保持上一状态
     min_silence_duration_ms: 100      # 最小静默时间（毫秒）
     sample_rate: 16000                # 采样率
     channels: 1                       # 声道数
@@ -119,6 +120,7 @@ vad:
   ten_vad:
     hop_size: 512                     # 帧移大小
     threshold: 0.4                    # VAD检测阈值
+    threshold_low: 0.25               # 退出语音阈值，低于该值切换为静音；介于 threshold_low 和 threshold 之间保持上一状态
     pool_size: 10                     # 资源池大小
     acquire_timeout_ms: 3000          # 获取超时时间（毫秒）
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -128,6 +128,7 @@ vad:
   silero_vad:
     model_path: "config/models/vad/silero_vad.onnx"  # 模型文件路径
     threshold: 0.5                    # 检测阈值
+    threshold_low: 0.35               # 退出语音阈值，低于该值切换为静音；介于 threshold_low 和 threshold 之间保持上一状态
     min_silence_duration_ms: 100      # 最小静默时间（毫秒）
     sample_rate: 16000                # 采样率
     channels: 1                       # 声道数
@@ -137,6 +138,7 @@ vad:
   ten_vad:
     hop_size: 512                     # 帧移大小
     threshold: 0.4                    # VAD检测阈值
+    threshold_low: 0.25               # 退出语音阈值，低于该值切换为静音；介于 threshold_low 和 threshold 之间保持上一状态
     pool_size: 10                     # 资源池大小
     acquire_timeout_ms: 3000          # 获取超时时间（毫秒）
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,6 +24,12 @@ chat_hooks:
     drop_when_full: false
     timeout_ms: 200
   plugins:
+    asr_noise_filter:
+      enabled: true
+      priority: 10
+      min_voice_duration_ms: 300
+      drop_phrases: ["嗯", "嗯嗯", "啊", "啊啊", "呃", "额", "唔", "哦", "噢", "标点符号", "标识符号", "句号", "逗号"]
+      keep_phrases: ["好", "对", "是", "停", "开", "关", "不"]
     statistic_plugin:
       enabled: true
       priority: 100

--- a/internal/app/server/chat/asr.go
+++ b/internal/app/server/chat/asr.go
@@ -809,11 +809,24 @@ func (a *ASRManager) StartAsrRecognitionLoop(
 					if stop {
 						log.Infof("ASR_OUTPUT hook 请求停止当前流程")
 						state.Asr.ClearHistoryAudio()
-						if state.UsesAudioIdleClock() {
-							startAudioIdle()
-						} else {
-							state.ResetAudioIdleWindow()
+
+						if !state.IsRealTime() {
+							if state.UsesAudioIdleClock() {
+								startAudioIdle()
+							} else {
+								state.ResetAudioIdleWindow()
+							}
+							return
 						}
+
+						if restartErr := a.RestartAsrRecognition(ctx); restartErr != nil {
+							log.Errorf("ASR_OUTPUT hook 停止流程后重启识别失败: %v", restartErr)
+							if onError != nil {
+								onError(restartErr)
+							}
+							return
+						}
+						startAudioIdle()
 						continue
 					}
 				}

--- a/internal/app/server/chat/asr.go
+++ b/internal/app/server/chat/asr.go
@@ -771,6 +771,7 @@ func (a *ASRManager) StartAsrRecognitionLoop(
 			}
 
 			if text != "" {
+				voiceDurationMs := state.Vad.GetVoiceDurationInSession()
 				asrFinalTs := time.Now().UnixMilli()
 				state.MarkAsrFinalTextAt(asrFinalTs)
 				if a.session != nil {
@@ -784,23 +785,6 @@ func (a *ASRManager) StartAsrRecognitionLoop(
 				emptyResultCount = 0
 				recoverableErrorWindowStart = time.Now()
 				recoverableErrorCount = 0
-
-				//如果是realtime模式下，需要停止 当前的llm和tts
-				if state.IsRealTime() && viper.GetInt("chat.realtime_mode") == 2 {
-					shouldInterrupt := true
-					if a.session != nil && a.session.isRealtimeMcpAudioGateActive() {
-						shouldInterrupt = false
-						log.Debugf("设备 %s realtime媒体播放门控激活，延后到ASR final门控判定，跳过ASR结果打断", state.DeviceID)
-					}
-					if shouldInterrupt {
-						log.Debugf("OnListenStart realtime模式下, 停止当前的llm和tts")
-						if a.session != nil {
-							a.session.StopAssistantOutputAfterAsrWithReason(true, "ASRManager.StartAsrRecognitionLoop realtime_mode=2 ASR result interrupt")
-						} else {
-							state.AfterAsrSessionCtx.CancelWithReason("ASRManager.StartAsrRecognitionLoop: realtime_mode=2 ASR result interrupt")
-						}
-					}
-				}
 
 				// 重置重试计数器
 				startIdleTime = time.Now().Unix()
@@ -816,7 +800,7 @@ func (a *ASRManager) StartAsrRecognitionLoop(
 				}
 
 				if a.session != nil {
-					payload, stop, hookErr := a.session.hookHub.EmitASROutput(a.session.hookContext(ctx), chathooks.ASROutputData{Text: text, SpeakerResult: speakerResult})
+					payload, stop, hookErr := a.session.hookHub.EmitASROutput(a.session.hookContext(ctx), chathooks.ASROutputData{Text: text, SpeakerResult: speakerResult, VoiceDurationMs: voiceDurationMs})
 					if hookErr != nil {
 						log.Warnf("ASR_OUTPUT hook 执行失败: %v", hookErr)
 					}
@@ -860,6 +844,23 @@ func (a *ASRManager) StartAsrRecognitionLoop(
 						}
 						startAudioIdle()
 						continue
+					}
+				}
+
+				//如果是realtime模式下，需要停止 当前的llm和tts
+				if state.IsRealTime() && viper.GetInt("chat.realtime_mode") == 2 {
+					shouldInterrupt := true
+					if a.session != nil && a.session.isRealtimeMcpAudioGateActive() {
+						shouldInterrupt = false
+						log.Debugf("设备 %s realtime媒体播放门控激活，延后到ASR final门控判定，跳过ASR结果打断", state.DeviceID)
+					}
+					if shouldInterrupt {
+						log.Debugf("OnListenStart realtime模式下, 停止当前的llm和tts")
+						if a.session != nil {
+							a.session.StopAssistantOutputAfterAsrWithReason(true, "ASRManager.StartAsrRecognitionLoop realtime_mode=2 ASR result interrupt")
+						} else {
+							state.AfterAsrSessionCtx.CancelWithReason("ASRManager.StartAsrRecognitionLoop: realtime_mode=2 ASR result interrupt")
+						}
 					}
 				}
 

--- a/internal/app/server/chat/asr.go
+++ b/internal/app/server/chat/asr.go
@@ -17,6 +17,7 @@ import (
 	chathooks "xiaozhi-esp32-server-golang/internal/domain/chat/hooks"
 	"xiaozhi-esp32-server-golang/internal/domain/speaker"
 	"xiaozhi-esp32-server-golang/internal/domain/vad/inter"
+	powervad "xiaozhi-esp32-server-golang/internal/domain/vad/power"
 	"xiaozhi-esp32-server-golang/internal/pool"
 	log "xiaozhi-esp32-server-golang/logger"
 
@@ -268,46 +269,48 @@ func (a *ASRManager) ProcessVadAudio(ctx context.Context) {
 				}
 
 				if !skipVad && needVad {
-					if !ensureVad() {
-						continue
-					}
-					//decode opus to pcm
-					state.AsrAudioBuffer.AddAsrAudioData(pcmData)
-
-					// 计算 VAD 需要的最小数据量
-					vadNeedMinSize := frameSize
-
-					if state.AsrAudioBuffer.GetAsrDataSize() >= vadNeedMinSize {
-						if isSileroVAD {
-							vadPcmData = pcmData
-						} else {
-							vadPcmData = state.AsrAudioBuffer.GetAsrData(vadNeedGetCount, frameSize)
-						}
-
-						//如果已经检测到语音, 则不进行vad检测, 直接将pcmData传给asr
-						// 使用循环外获取的VAD资源进行检测
-						if !keepVadStateBetweenFrames {
-							vadLastUseAt = time.Now()
-							if err := vadProvider.Reset(); err != nil {
-								log.Errorf("重置vad失败: %v", err)
-								continue
-							}
-						}
-
-						// 进行VAD检测
-						vadLastUseAt = time.Now()
-						haveVoice, err = vadProvider.IsVADExt(vadPcmData, audioFormat.SampleRate, frameSize)
-						if err != nil {
-							log.Errorf("processAsrAudio VAD检测失败: %v", err)
+					if !shouldSkipSileroByPower(isSileroVAD, clientHaveVoice, pcmData) {
+						if !ensureVad() {
 							continue
 						}
+						//decode opus to pcm
+						state.AsrAudioBuffer.AddAsrAudioData(pcmData)
 
-						//首次触发识别到语音时,为了语音数据完整性 将vadPcmData赋值给pcmData, 之后的音频数据全部进入asr
-						if haveVoice && !clientHaveVoice {
-							//首次检测到语音时，最多只保留200ms的前静音数据
-							currentFrameSamples := len(pcmData)
-							allData := state.AsrAudioBuffer.GetAndClearAllData()
-							pcmData = trimFirstSpeechAudio(allData, currentFrameSamples, audioFormat.SampleRate, audioFormat.Channels)
+						// 计算 VAD 需要的最小数据量
+						vadNeedMinSize := frameSize
+
+						if state.AsrAudioBuffer.GetAsrDataSize() >= vadNeedMinSize {
+							if isSileroVAD {
+								vadPcmData = pcmData
+							} else {
+								vadPcmData = state.AsrAudioBuffer.GetAsrData(vadNeedGetCount, frameSize)
+							}
+
+							//如果已经检测到语音, 则不进行vad检测, 直接将pcmData传给asr
+							// 使用循环外获取的VAD资源进行检测
+							if !keepVadStateBetweenFrames {
+								vadLastUseAt = time.Now()
+								if err := vadProvider.Reset(); err != nil {
+									log.Errorf("重置vad失败: %v", err)
+									continue
+								}
+							}
+
+							// 进行VAD检测
+							vadLastUseAt = time.Now()
+							haveVoice, err = vadProvider.IsVADExt(vadPcmData, audioFormat.SampleRate, frameSize)
+							if err != nil {
+								log.Errorf("processAsrAudio VAD检测失败: %v", err)
+								continue
+							}
+
+							//首次触发识别到语音时,为了语音数据完整性 将vadPcmData赋值给pcmData, 之后的音频数据全部进入asr
+							if haveVoice && !clientHaveVoice {
+								//首次检测到语音时，最多只保留200ms的前静音数据
+								currentFrameSamples := len(pcmData)
+								allData := state.AsrAudioBuffer.GetAndClearAllData()
+								pcmData = trimFirstSpeechAudio(allData, currentFrameSamples, audioFormat.SampleRate, audioFormat.Channels)
+							}
 						}
 					}
 					//log.Debugf("isVad, pcmData len: %d, vadPcmData len: %d, haveVoice: %v", len(pcmData), len(vadPcmData), haveVoice)
@@ -1075,6 +1078,10 @@ func trimFirstSpeechAudio(allData []float32, currentFrameSamples, sampleRate, ch
 	audio := make([]float32, keepSamples)
 	copy(audio, allData[len(allData)-keepSamples:])
 	return audio
+}
+
+func shouldSkipSileroByPower(isSileroVAD, clientHaveVoice bool, pcmData []float32) bool {
+	return isSileroVAD && !clientHaveVoice && powervad.IsSilent(pcmData)
 }
 
 // getSpeakerResult 获取暂存的声纹结果（带超时）

--- a/internal/app/server/chat/asr.go
+++ b/internal/app/server/chat/asr.go
@@ -156,6 +156,7 @@ func (a *ASRManager) ProcessVadAudio(ctx context.Context) {
 			effectiveVadProviderName = configProvider
 		}
 		isSileroVAD := effectiveVadProviderName == "silero_vad"
+		keepVadStateBetweenFrames := isSileroVAD || effectiveVadProviderName == "ten_vad"
 		releaseVad := func(reason string) {
 			if vadWrapper == nil {
 				return
@@ -285,7 +286,7 @@ func (a *ASRManager) ProcessVadAudio(ctx context.Context) {
 
 						//如果已经检测到语音, 则不进行vad检测, 直接将pcmData传给asr
 						// 使用循环外获取的VAD资源进行检测
-						if !isSileroVAD {
+						if !keepVadStateBetweenFrames {
 							vadLastUseAt = time.Now()
 							if err := vadProvider.Reset(); err != nil {
 								log.Errorf("重置vad失败: %v", err)

--- a/internal/app/server/chat/asr_power_vad_test.go
+++ b/internal/app/server/chat/asr_power_vad_test.go
@@ -1,0 +1,18 @@
+package chat
+
+import "testing"
+
+func TestShouldSkipSileroByPowerOnlyBeforeVoiceStarts(t *testing.T) {
+	if !shouldSkipSileroByPower(true, false, []float32{0, 0, 0.001, -0.001}) {
+		t.Fatal("silent Silero frame before voice starts should be skipped")
+	}
+	if shouldSkipSileroByPower(false, false, []float32{0, 0, 0.001, -0.001}) {
+		t.Fatal("non-Silero VAD should not use power skip")
+	}
+	if shouldSkipSileroByPower(true, true, []float32{0, 0, 0.001, -0.001}) {
+		t.Fatal("Silero frame after voice starts should not be skipped")
+	}
+	if shouldSkipSileroByPower(true, false, []float32{0.02, 0, 0, 0}) {
+		t.Fatal("audible Silero frame should not be skipped")
+	}
+}

--- a/internal/app/server/chat/session.go
+++ b/internal/app/server/chat/session.go
@@ -242,6 +242,18 @@ func NewChatSession(clientState *ClientState, serverTransport *ServerTransport, 
 
 	// 设置 ASR 首次返回字符的回调
 	clientState.OnAsrFirstTextCallback = func(text string, isFinal bool) {
+		voiceDurationMs := clientState.Vad.GetVoiceDurationInSession()
+		if drop, reason := chathooks.ShouldDropConfiguredASRNoiseText(text, voiceDurationMs); drop {
+			log.Infof(
+				"ASR首文本噪声过滤命中，跳过首字状态和realtime打断: device=%s, reason=%s, voice_duration_ms=%d, text=%q, isFinal=%v",
+				clientState.DeviceID,
+				reason,
+				voiceDurationMs,
+				text,
+				isFinal,
+			)
+			return
+		}
 		clientState.Asr.MarkTextReceived()
 		clientState.ClearAudioIdleTimeoutPending()
 		clientState.PauseAudioIdleWindow(time.Now())

--- a/internal/domain/chat/hooks/asr_noise_filter.go
+++ b/internal/domain/chat/hooks/asr_noise_filter.go
@@ -1,0 +1,182 @@
+package hooks
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/spf13/viper"
+
+	log "xiaozhi-esp32-server-golang/logger"
+)
+
+const asrNoiseFilterConfigPath = "chat_hooks.plugins.asr_noise_filter"
+
+var defaultASRNoiseDropPhrases = []string{
+	"嗯", "嗯嗯",
+	"啊", "啊啊",
+	"呃", "额",
+	"唔",
+	"哦", "噢",
+	"标点符号", "标识符号",
+	"句号", "逗号",
+}
+
+var defaultASRNoiseKeepPhrases = []string{
+	"好",
+	"对",
+	"是",
+	"停",
+	"开",
+	"关",
+	"不",
+}
+
+type ASRNoiseFilterConfig struct {
+	Enabled            bool
+	MinVoiceDurationMs int64
+	DropPhrases        []string
+	KeepPhrases        []string
+}
+
+func DefaultASRNoiseFilterConfig() ASRNoiseFilterConfig {
+	return ASRNoiseFilterConfig{
+		Enabled:            false,
+		MinVoiceDurationMs: 300,
+		DropPhrases:        cloneStringSlice(defaultASRNoiseDropPhrases),
+		KeepPhrases:        cloneStringSlice(defaultASRNoiseKeepPhrases),
+	}
+}
+
+func LoadASRNoiseFilterConfig() ASRNoiseFilterConfig {
+	cfg := DefaultASRNoiseFilterConfig()
+
+	if viper.IsSet(asrNoiseFilterConfigPath + ".enabled") {
+		cfg.Enabled = viper.GetBool(asrNoiseFilterConfigPath + ".enabled")
+	}
+	if viper.IsSet(asrNoiseFilterConfigPath + ".min_voice_duration_ms") {
+		cfg.MinVoiceDurationMs = viper.GetInt64(asrNoiseFilterConfigPath + ".min_voice_duration_ms")
+	}
+	if viper.IsSet(asrNoiseFilterConfigPath + ".drop_phrases") {
+		cfg.DropPhrases = viper.GetStringSlice(asrNoiseFilterConfigPath + ".drop_phrases")
+	}
+	if viper.IsSet(asrNoiseFilterConfigPath + ".keep_phrases") {
+		cfg.KeepPhrases = viper.GetStringSlice(asrNoiseFilterConfigPath + ".keep_phrases")
+	}
+
+	return cfg
+}
+
+func ShouldDropConfiguredASRNoiseText(text string, voiceDurationMs int64) (bool, string) {
+	return ShouldDropASRNoiseText(text, voiceDurationMs, LoadASRNoiseFilterConfig())
+}
+
+func ShouldDropASRNoiseText(text string, voiceDurationMs int64, cfg ASRNoiseFilterConfig) (bool, string) {
+	if !cfg.Enabled {
+		return false, "disabled"
+	}
+
+	if strings.TrimSpace(text) == "" {
+		return false, "empty"
+	}
+
+	normalized := normalizeASRNoiseText(text)
+	if normalized == "" {
+		return true, "punctuation_only"
+	}
+
+	if containsNormalizedASRPhrase(cfg.KeepPhrases, normalized) {
+		return false, "keep_phrase"
+	}
+
+	if containsNormalizedASRPhrase(cfg.DropPhrases, normalized) {
+		return true, "drop_phrase"
+	}
+
+	if cfg.MinVoiceDurationMs > 0 &&
+		voiceDurationMs > 0 &&
+		voiceDurationMs < cfg.MinVoiceDurationMs &&
+		isLikelyShortFiller(normalized) {
+		return true, "short_filler"
+	}
+
+	return false, "not_noise"
+}
+
+func newASRNoiseFilterRegistration() Registration {
+	meta := PluginMeta{
+		Name:        "asr_noise_filter",
+		Version:     "v1",
+		Description: "Drop short ASR filler or punctuation-only results before STT/LLM",
+		Priority:    10,
+		Enabled:     false,
+		Kind:        PluginKindInterceptor,
+		Stage:       EventChatASROutput,
+	}
+	return Registration{
+		Meta: meta,
+		Register: func(hub *Hub, meta PluginMeta) error {
+			return hub.RegisterInterceptor(EventChatASROutput, meta, func(ctx Context, payload any) (any, bool, error) {
+				data, ok := payload.(ASROutputData)
+				if !ok {
+					return payload, false, nil
+				}
+
+				drop, reason := ShouldDropConfiguredASRNoiseText(data.Text, data.VoiceDurationMs)
+				if !drop {
+					return payload, false, nil
+				}
+
+				log.Infof(
+					"ASR噪声过滤命中，跳过STT/LLM: device=%s, session=%s, reason=%s, voice_duration_ms=%d, text=%q",
+					ctx.DeviceID,
+					ctx.SessionID,
+					reason,
+					data.VoiceDurationMs,
+					data.Text,
+				)
+				return data, true, nil
+			})
+		},
+	}
+}
+
+func normalizeASRNoiseText(text string) string {
+	var b strings.Builder
+	for _, r := range text {
+		if unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) {
+			continue
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+func containsNormalizedASRPhrase(phrases []string, normalizedText string) bool {
+	for _, phrase := range phrases {
+		if normalizeASRNoiseText(phrase) == normalizedText {
+			return true
+		}
+	}
+	return false
+}
+
+func isLikelyShortFiller(normalized string) bool {
+	runes := []rune(normalized)
+	if len(runes) == 0 || len(runes) > 2 {
+		return false
+	}
+	for _, r := range runes {
+		switch r {
+		case '嗯', '啊', '呃', '额', '唔', '哦', '噢', '哼':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func cloneStringSlice(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/domain/chat/hooks/asr_noise_filter_test.go
+++ b/internal/domain/chat/hooks/asr_noise_filter_test.go
@@ -1,0 +1,65 @@
+package hooks
+
+import "testing"
+
+func TestShouldDropASRNoiseTextDropsPunctuationOnly(t *testing.T) {
+	cfg := DefaultASRNoiseFilterConfig()
+	cfg.Enabled = true
+
+	drop, reason := ShouldDropASRNoiseText("。。。？！", 0, cfg)
+
+	if !drop {
+		t.Fatalf("ShouldDropASRNoiseText() drop = false, want true")
+	}
+	if reason != "punctuation_only" {
+		t.Fatalf("ShouldDropASRNoiseText() reason = %q, want punctuation_only", reason)
+	}
+}
+
+func TestShouldDropASRNoiseTextDropsConfiguredPhrasesAfterNormalization(t *testing.T) {
+	cfg := DefaultASRNoiseFilterConfig()
+	cfg.Enabled = true
+
+	cases := []string{
+		"嗯。",
+		"啊",
+		"标识符号",
+		"标点符号。",
+	}
+
+	for _, text := range cases {
+		drop, reason := ShouldDropASRNoiseText(text, 120, cfg)
+		if !drop {
+			t.Fatalf("ShouldDropASRNoiseText(%q) drop = false, want true", text)
+		}
+		if reason != "drop_phrase" {
+			t.Fatalf("ShouldDropASRNoiseText(%q) reason = %q, want drop_phrase", text, reason)
+		}
+	}
+}
+
+func TestShouldDropASRNoiseTextKeepsConfiguredShortCommands(t *testing.T) {
+	cfg := DefaultASRNoiseFilterConfig()
+	cfg.Enabled = true
+
+	for _, text := range []string{"好。", "停", "开", "关"} {
+		drop, reason := ShouldDropASRNoiseText(text, 80, cfg)
+		if drop {
+			t.Fatalf("ShouldDropASRNoiseText(%q) drop = true reason=%q, want false", text, reason)
+		}
+	}
+}
+
+func TestShouldDropASRNoiseTextKeepsNoiseWhenDisabled(t *testing.T) {
+	cfg := DefaultASRNoiseFilterConfig()
+	cfg.Enabled = false
+
+	drop, reason := ShouldDropASRNoiseText("嗯。", 80, cfg)
+
+	if drop {
+		t.Fatalf("ShouldDropASRNoiseText() drop = true reason=%q, want false", reason)
+	}
+	if reason != "disabled" {
+		t.Fatalf("ShouldDropASRNoiseText() reason = %q, want disabled", reason)
+	}
+}

--- a/internal/domain/chat/hooks/statistic_plugin.go
+++ b/internal/domain/chat/hooks/statistic_plugin.go
@@ -68,13 +68,16 @@ func BuiltinRegistrations() []Registration {
 		Kind:        PluginKindInterceptor,
 		Stage:       EventChatMetric,
 	}
-	return []Registration{{
-		Meta:      meta,
-		Lifecycle: plugin,
-		Register: func(hub *Hub, meta PluginMeta) error {
-			return hub.RegisterInterceptor(EventChatMetric, meta, plugin.onMetricSync)
+	return []Registration{
+		newASRNoiseFilterRegistration(),
+		{
+			Meta:      meta,
+			Lifecycle: plugin,
+			Register: func(hub *Hub, meta PluginMeta) error {
+				return hub.RegisterInterceptor(EventChatMetric, meta, plugin.onMetricSync)
+			},
 		},
-	}}
+	}
 }
 
 func (p *statisticPlugin) onMetricSync(ctx Context, payload any) (any, bool, error) {

--- a/internal/domain/chat/hooks/types.go
+++ b/internal/domain/chat/hooks/types.go
@@ -116,8 +116,9 @@ func ValidateEventKind(event string, kind PluginKind) error {
 }
 
 type ASROutputData struct {
-	Text          string
-	SpeakerResult *speaker.IdentifyResult
+	Text            string
+	SpeakerResult   *speaker.IdentifyResult
+	VoiceDurationMs int64
 }
 
 type LLMInputData struct {

--- a/internal/domain/vad/hysteresis/hysteresis.go
+++ b/internal/domain/vad/hysteresis/hysteresis.go
@@ -1,0 +1,49 @@
+package hysteresis
+
+type Detector struct {
+	High   float32
+	Low    float32
+	active bool
+}
+
+func NewDetector(high, low float32) *Detector {
+	if high < 0 {
+		high = 0
+	}
+	if high > 1 {
+		high = 1
+	}
+	if low < 0 || low > high {
+		low = high
+	}
+	return &Detector{High: high, Low: low}
+}
+
+func (d *Detector) Evaluate(score float32) bool {
+	if d == nil {
+		return false
+	}
+	if score >= d.High {
+		d.active = true
+		return true
+	}
+	if score <= d.Low {
+		d.active = false
+		return false
+	}
+	return d.active
+}
+
+func (d *Detector) Reset() {
+	if d == nil {
+		return
+	}
+	d.active = false
+}
+
+func (d *Detector) Active() bool {
+	if d == nil {
+		return false
+	}
+	return d.active
+}

--- a/internal/domain/vad/hysteresis/hysteresis_test.go
+++ b/internal/domain/vad/hysteresis/hysteresis_test.go
@@ -1,0 +1,56 @@
+package hysteresis
+
+import "testing"
+
+func TestDetectorKeepsPreviousStateBetweenThresholds(t *testing.T) {
+	d := NewDetector(0.5, 0.35)
+
+	if got := d.Evaluate(0.49); got {
+		t.Fatalf("Evaluate(0.49) before speech = true, want false")
+	}
+	if got := d.Evaluate(0.51); !got {
+		t.Fatalf("Evaluate(0.51) = false, want true")
+	}
+	if got := d.Evaluate(0.42); !got {
+		t.Fatalf("Evaluate(0.42) after speech = false, want true")
+	}
+	if got := d.Evaluate(0.34); got {
+		t.Fatalf("Evaluate(0.34) = true, want false")
+	}
+}
+
+func TestDetectorUsesSingleThresholdWhenLowEqualsHigh(t *testing.T) {
+	d := NewDetector(0.5, 0.5)
+
+	if got := d.Evaluate(0.51); !got {
+		t.Fatalf("Evaluate(0.51) = false, want true")
+	}
+	if got := d.Evaluate(0.49); got {
+		t.Fatalf("Evaluate(0.49) = true, want false")
+	}
+}
+
+func TestDetectorAllowsZeroLowThreshold(t *testing.T) {
+	d := NewDetector(0.5, 0)
+
+	if got := d.Evaluate(0.51); !got {
+		t.Fatalf("Evaluate(0.51) = false, want true")
+	}
+	if got := d.Evaluate(0.1); !got {
+		t.Fatalf("Evaluate(0.1) after speech = false, want true")
+	}
+	if got := d.Evaluate(0); got {
+		t.Fatalf("Evaluate(0) = true, want false")
+	}
+}
+
+func TestDetectorNormalizesInvalidLowThreshold(t *testing.T) {
+	d := NewDetector(0.5, 0.7)
+
+	if got := d.Evaluate(0.51); !got {
+		t.Fatalf("Evaluate(0.51) = false, want true")
+	}
+	if got := d.Evaluate(0.49); got {
+		t.Fatalf("Evaluate(0.49) = true, want false")
+	}
+}

--- a/internal/domain/vad/power/power_vad.go
+++ b/internal/domain/vad/power/power_vad.go
@@ -1,0 +1,30 @@
+package power
+
+import "math"
+
+const (
+	rmsThreshold  float32 = 0.003
+	peakThreshold float32 = 0.015
+)
+
+func IsSilent(pcm []float32) bool {
+	if len(pcm) == 0 {
+		return true
+	}
+
+	var sumSquares float64
+	var peak float32
+	for _, sample := range pcm {
+		abs := sample
+		if abs < 0 {
+			abs = -abs
+		}
+		if abs > peak {
+			peak = abs
+		}
+		sumSquares += float64(sample * sample)
+	}
+
+	rms := float32(math.Sqrt(sumSquares / float64(len(pcm))))
+	return rms < rmsThreshold && peak < peakThreshold
+}

--- a/internal/domain/vad/power/power_vad_test.go
+++ b/internal/domain/vad/power/power_vad_test.go
@@ -1,0 +1,31 @@
+package power
+
+import "testing"
+
+func TestIsSilentDropsZeroOrVeryLowPower(t *testing.T) {
+	if !IsSilent(nil) {
+		t.Fatal("nil audio should be silent")
+	}
+	if !IsSilent([]float32{0, 0, 0, 0}) {
+		t.Fatal("zero audio should be silent")
+	}
+	if !IsSilent([]float32{0.001, -0.001, 0.001, -0.001}) {
+		t.Fatal("very low power audio should be silent")
+	}
+}
+
+func TestIsSilentKeepsRMSAboveThreshold(t *testing.T) {
+	pcm := []float32{0.004, -0.004, 0.004, -0.004}
+
+	if IsSilent(pcm) {
+		t.Fatal("audio with RMS above threshold should not be silent")
+	}
+}
+
+func TestIsSilentKeepsPeakAboveThreshold(t *testing.T) {
+	pcm := []float32{0, 0, 0.02, 0}
+
+	if IsSilent(pcm) {
+		t.Fatal("audio with peak above threshold should not be silent")
+	}
+}

--- a/internal/domain/vad/silero_vad/vad.go
+++ b/internal/domain/vad/silero_vad/vad.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"xiaozhi-esp32-server-golang/internal/domain/vad/hysteresis"
 	. "xiaozhi-esp32-server-golang/internal/domain/vad/inter"
 	log "xiaozhi-esp32-server-golang/logger"
 
@@ -17,6 +18,7 @@ import (
 
 var defaultVADConfig = map[string]interface{}{
 	"threshold":               0.5,
+	"threshold_low":           0.5,
 	"min_silence_duration_ms": 100,
 	"sample_rate":             16000,
 	"channels":                1,
@@ -56,6 +58,7 @@ type SileroVAD struct {
 	stream     *speech.Stream
 
 	vadThreshold     float32
+	vadThresholdLow  float32
 	silenceThreshold int
 	speechPadMs      int
 	sampleRate       int
@@ -63,6 +66,7 @@ type SileroVAD struct {
 
 	pending   []float32
 	lastVoice bool
+	detector  *hysteresis.Detector
 	closed    bool
 	mu        sync.Mutex
 }
@@ -80,6 +84,7 @@ func NewSileroVAD(config map[string]interface{}) (*SileroVAD, error) {
 	modelPath = resolvedModelPath
 
 	threshold := getFloat32(cfg, "threshold", 0.5)
+	thresholdLow := getFloat32(cfg, "threshold_low", threshold)
 	silenceMs := getDurationMs(cfg, "min_silence_duration_ms", "min_silence_duration", 100)
 	sampleRate := getInt(cfg, "sample_rate", 16000)
 	channels := getInt(cfg, "channels", 1)
@@ -126,10 +131,12 @@ func NewSileroVAD(config map[string]interface{}) (*SileroVAD, error) {
 		runtimeKey:       key,
 		stream:           stream,
 		vadThreshold:     threshold,
+		vadThresholdLow:  thresholdLow,
 		silenceThreshold: silenceMs,
 		speechPadMs:      speechPadMs,
 		sampleRate:       sampleRate,
 		channels:         channels,
+		detector:         hysteresis.NewDetector(threshold, thresholdLow),
 	}, nil
 }
 
@@ -143,6 +150,9 @@ func (s *SileroVAD) IsVADExt(pcmData []float32, sampleRate int, frameSize int) (
 
 	if s.closed || s.stream == nil || s.runtime == nil {
 		return false, errors.New("Silero VAD实例未初始化")
+	}
+	if s.detector == nil {
+		s.detector = hysteresis.NewDetector(s.vadThreshold, s.vadThresholdLow)
 	}
 	if len(pcmData) == 0 {
 		return false, nil
@@ -164,7 +174,8 @@ func (s *SileroVAD) IsVADExt(pcmData []float32, sampleRate int, frameSize int) (
 	s.pending = append(s.pending, pcm...)
 	windowSize := sileroWindowSize(s.sampleRate)
 	processed := 0
-	haveVoice := false
+	haveVoice := s.lastVoice
+	chunkHasVoice := false
 	didInfer := false
 
 	for processed+windowSize <= len(s.pending) {
@@ -173,8 +184,9 @@ func (s *SileroVAD) IsVADExt(pcmData []float32, sampleRate int, frameSize int) (
 			return false, err
 		}
 		didInfer = true
-		if probability >= s.vadThreshold {
-			haveVoice = true
+		haveVoice = s.detector.Evaluate(probability)
+		if haveVoice {
+			chunkHasVoice = true
 		}
 		processed += windowSize
 	}
@@ -185,7 +197,7 @@ func (s *SileroVAD) IsVADExt(pcmData []float32, sampleRate int, frameSize int) (
 	}
 	if didInfer {
 		s.lastVoice = haveVoice
-		return haveVoice, nil
+		return chunkHasVoice, nil
 	}
 	return s.lastVoice, nil
 }
@@ -231,6 +243,9 @@ func (s *SileroVAD) Reset() error {
 	}
 	s.pending = nil
 	s.lastVoice = false
+	if s.detector != nil {
+		s.detector.Reset()
+	}
 	return s.stream.Reset()
 }
 
@@ -238,6 +253,7 @@ func (s *SileroVAD) SetThreshold(threshold float32) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.vadThreshold = threshold
+	s.detector = hysteresis.NewDetector(s.vadThreshold, s.vadThresholdLow)
 	if s.stream != nil {
 		s.stream.SetThreshold(threshold)
 	}
@@ -257,6 +273,9 @@ func (s *SileroVAD) resetStreamLocked(sampleRate int) error {
 	s.sampleRate = sampleRate
 	s.pending = nil
 	s.lastVoice = false
+	if s.detector != nil {
+		s.detector.Reset()
+	}
 	return nil
 }
 

--- a/internal/domain/vad/ten_vad/vad.go
+++ b/internal/domain/vad/ten_vad/vad.go
@@ -8,21 +8,25 @@ import (
 
 	log "xiaozhi-esp32-server-golang/logger"
 
+	"xiaozhi-esp32-server-golang/internal/domain/vad/hysteresis"
 	. "xiaozhi-esp32-server-golang/internal/domain/vad/inter"
 )
 
 // VAD默认配置
 var defaultVADConfig = map[string]interface{}{
-	"hop_size":  512,
-	"threshold": 0.3,
+	"hop_size":      512,
+	"threshold":     0.3,
+	"threshold_low": 0.3,
 }
 
 // TenVAD TEN-VAD模型实现
 type TenVAD struct {
-	handle    unsafe.Pointer
-	hopSize   int
-	threshold float32
-	mu        sync.Mutex
+	handle       unsafe.Pointer
+	hopSize      int
+	threshold    float32
+	thresholdLow float32
+	detector     *hysteresis.Detector
+	mu           sync.Mutex
 }
 
 // NewTenVAD 创建TenVAD实例
@@ -46,6 +50,7 @@ func NewTenVAD(config map[string]interface{}) (*TenVAD, error) {
 			threshold = 0.3 // 默认值
 		}
 	}
+	thresholdLow := getConfigFloat32(config, "threshold_low", float32(threshold))
 
 	// 创建TEN-VAD实例
 	tenVAD := GetInstance()
@@ -54,12 +59,14 @@ func NewTenVAD(config map[string]interface{}) (*TenVAD, error) {
 		return nil, fmt.Errorf("创建TEN-VAD实例失败: %v", err)
 	}
 
-	log.Debugf("创建TEN-VAD实例成功, hopSize: %d, threshold: %f", hopSize, threshold)
+	log.Debugf("创建TEN-VAD实例成功, hopSize: %d, threshold: %f, threshold_low: %f", hopSize, threshold, thresholdLow)
 
 	return &TenVAD{
-		handle:    handle,
-		hopSize:   hopSize,
-		threshold: float32(threshold),
+		handle:       handle,
+		hopSize:      hopSize,
+		threshold:    float32(threshold),
+		thresholdLow: thresholdLow,
+		detector:     hysteresis.NewDetector(float32(threshold), thresholdLow),
 	}, nil
 }
 
@@ -75,6 +82,9 @@ func (t *TenVAD) IsVADExt(pcmData []float32, sampleRate int, frameSize int) (boo
 
 	if t.handle == nil {
 		return false, errors.New("TEN-VAD实例未初始化")
+	}
+	if t.detector == nil {
+		t.detector = hysteresis.NewDetector(t.threshold, t.thresholdLow)
 	}
 
 	if len(pcmData) == 0 {
@@ -114,14 +124,13 @@ func (t *TenVAD) IsVADExt(pcmData []float32, sampleRate int, frameSize int) (boo
 			continue
 		}
 
-		_, flag, err := tenVAD.ProcessAudio(t.handle, frame)
+		probability, _, err := tenVAD.ProcessAudio(t.handle, frame)
 		if err != nil {
 			log.Errorf("TEN-VAD处理音频帧失败: %v", err)
 			continue
 		}
 
-		// flag == 1 表示检测到语音
-		if flag == 1 {
+		if t.detector.Evaluate(probability) {
 			hasVoice = true
 			voiceFrameCount++
 		}
@@ -136,9 +145,9 @@ func (t *TenVAD) Reset() error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	// TEN-VAD不需要重置，每次处理都是独立的
-	// 但我们可以重新创建实例来重置状态
-	// 这里不做任何操作，因为TEN-VAD是无状态的
+	if t.detector != nil {
+		t.detector.Reset()
+	}
 	return nil
 }
 
@@ -176,4 +185,20 @@ func ReleaseVAD(vad VAD) error {
 		return vad.Close()
 	}
 	return nil
+}
+
+func getConfigFloat32(config map[string]interface{}, key string, fallback float32) float32 {
+	switch value := config[key].(type) {
+	case float32:
+		return value
+	case float64:
+		return float32(value)
+	case int:
+		return float32(value)
+	case int64:
+		return float32(value)
+	case int32:
+		return float32(value)
+	}
+	return fallback
 }

--- a/manager/frontend/src/views/admin/ConfigWizard.vue
+++ b/manager/frontend/src/views/admin/ConfigWizard.vue
@@ -202,6 +202,7 @@ const vadForm = reactive({
   silero_vad: {
     model_path: 'config/models/vad/silero_vad.onnx',
     threshold: 0.5,
+    threshold_low: 0.35,
     min_silence_duration_ms: 100,
     sample_rate: 16000,
     channels: 1,
@@ -210,23 +211,48 @@ const vadForm = reactive({
   ten_vad: {
     hop_size: 320,
     threshold: 0.3,
+    threshold_low: 0.2,
     pool_size: 10,
     acquire_timeout_ms: 3000
   }
 })
 const vadFormRef = ref()
+const validateSileroThresholdLow = (rule, value, callback) => {
+  if (Number(value) > Number(vadForm.silero_vad.threshold)) {
+    callback(new Error('退出阈值不能高于进入阈值'))
+    return
+  }
+  callback()
+}
+
+const validateTenThresholdLow = (rule, value, callback) => {
+  if (Number(value) > Number(vadForm.ten_vad.threshold)) {
+    callback(new Error('退出阈值不能高于进入阈值'))
+    return
+  }
+  callback()
+}
+
 const vadFormRules = {
   name: [{ required: true, message: '请输入配置名称', trigger: 'blur' }],
   config_id: [{ required: true, message: '请输入配置ID', trigger: 'blur' }],
   provider: [{ required: true, message: '请选择提供商', trigger: 'change' }],
   'silero_vad.model_path': [{ required: true, message: '请输入模型路径', trigger: 'blur' }],
-  'silero_vad.threshold': [{ required: true, message: '请输入阈值', trigger: 'blur' }],
+  'silero_vad.threshold': [{ required: true, message: '请输入进入阈值', trigger: 'blur' }],
+  'silero_vad.threshold_low': [
+    { required: true, message: '请输入退出阈值', trigger: 'blur' },
+    { validator: validateSileroThresholdLow, trigger: 'blur' }
+  ],
   'silero_vad.min_silence_duration_ms': [{ required: true, message: '请输入最小静音持续时间', trigger: 'blur' }],
   'silero_vad.sample_rate': [{ required: true, message: '请选择采样率', trigger: 'change' }],
   'silero_vad.channels': [{ required: true, message: '请选择声道数', trigger: 'change' }],
   'silero_vad.acquire_timeout_ms': [{ required: true, message: '请输入获取超时时间', trigger: 'blur' }],
   'ten_vad.hop_size': [{ required: true, message: '请输入帧移大小', trigger: 'blur' }],
-  'ten_vad.threshold': [{ required: true, message: '请输入VAD检测阈值', trigger: 'blur' }],
+  'ten_vad.threshold': [{ required: true, message: '请输入进入阈值', trigger: 'blur' }],
+  'ten_vad.threshold_low': [
+    { required: true, message: '请输入退出阈值', trigger: 'blur' },
+    { validator: validateTenThresholdLow, trigger: 'blur' }
+  ],
   'ten_vad.pool_size': [{ required: true, message: '请输入连接池大小', trigger: 'blur' }],
   'ten_vad.acquire_timeout_ms': [{ required: true, message: '请输入获取超时时间', trigger: 'blur' }]
 }

--- a/manager/frontend/src/views/admin/VADConfig.vue
+++ b/manager/frontend/src/views/admin/VADConfig.vue
@@ -140,6 +140,7 @@ const form = reactive({
   silero_vad: {
     model_path: 'config/models/vad/silero_vad.onnx',
     threshold: 0.5,
+    threshold_low: 0.35,
     min_silence_duration_ms: 100,
     sample_rate: 16000,
     channels: 1,
@@ -148,10 +149,27 @@ const form = reactive({
   ten_vad: {
     hop_size: 320,
     threshold: 0.3,
+    threshold_low: 0.2,
     pool_size: 10,
     acquire_timeout_ms: 3000
   }
 })
+
+const validateSileroThresholdLow = (rule, value, callback) => {
+  if (Number(value) > Number(form.silero_vad.threshold)) {
+    callback(new Error('退出阈值不能高于进入阈值'))
+    return
+  }
+  callback()
+}
+
+const validateTenThresholdLow = (rule, value, callback) => {
+  if (Number(value) > Number(form.ten_vad.threshold)) {
+    callback(new Error('退出阈值不能高于进入阈值'))
+    return
+  }
+  callback()
+}
 
 const rules = {
   name: [{ required: true, message: '请输入配置名称', trigger: 'blur' }],
@@ -163,13 +181,21 @@ const rules = {
   'webrtc_vad.vad_sample_rate': [{ required: true, message: '请选择VAD采样率', trigger: 'change' }],
   'webrtc_vad.vad_mode': [{ required: true, message: '请选择VAD模式', trigger: 'change' }],
   'silero_vad.model_path': [{ required: true, message: '请输入模型路径', trigger: 'blur' }],
-  'silero_vad.threshold': [{ required: true, message: '请输入阈值', trigger: 'blur' }],
+  'silero_vad.threshold': [{ required: true, message: '请输入进入阈值', trigger: 'blur' }],
+  'silero_vad.threshold_low': [
+    { required: true, message: '请输入退出阈值', trigger: 'blur' },
+    { validator: validateSileroThresholdLow, trigger: 'blur' }
+  ],
   'silero_vad.min_silence_duration_ms': [{ required: true, message: '请输入最小静音持续时间', trigger: 'blur' }],
   'silero_vad.sample_rate': [{ required: true, message: '请选择采样率', trigger: 'change' }],
   'silero_vad.channels': [{ required: true, message: '请选择声道数', trigger: 'change' }],
   'silero_vad.acquire_timeout_ms': [{ required: true, message: '请输入获取超时时间', trigger: 'blur' }],
   'ten_vad.hop_size': [{ required: true, message: '请输入帧移大小', trigger: 'blur' }],
-  'ten_vad.threshold': [{ required: true, message: '请输入VAD检测阈值', trigger: 'blur' }],
+  'ten_vad.threshold': [{ required: true, message: '请输入进入阈值', trigger: 'blur' }],
+  'ten_vad.threshold_low': [
+    { required: true, message: '请输入退出阈值', trigger: 'blur' },
+    { validator: validateTenThresholdLow, trigger: 'blur' }
+  ],
   'ten_vad.pool_size': [{ required: true, message: '请输入连接池大小', trigger: 'blur' }],
   'ten_vad.acquire_timeout_ms': [{ required: true, message: '请输入获取超时时间', trigger: 'blur' }]
 }
@@ -437,6 +463,7 @@ const resetForm = () => {
     silero_vad: {
       model_path: 'config/models/vad/silero_vad.onnx',
       threshold: 0.5,
+      threshold_low: 0.35,
       min_silence_duration_ms: 100,
       sample_rate: 16000,
       channels: 1,
@@ -445,6 +472,7 @@ const resetForm = () => {
     ten_vad: {
       hop_size: 320,
       threshold: 0.3,
+      threshold_low: 0.2,
       pool_size: 10,
       acquire_timeout_ms: 3000
     }

--- a/manager/frontend/src/views/admin/forms/VADConfigForm.vue
+++ b/manager/frontend/src/views/admin/forms/VADConfigForm.vue
@@ -45,8 +45,11 @@
       <el-form-item label="模型路径" prop="silero_vad.model_path">
         <el-input v-model="model.silero_vad.model_path" placeholder="请输入模型文件路径" />
       </el-form-item>
-      <el-form-item label="阈值" prop="silero_vad.threshold">
+      <el-form-item label="进入阈值" prop="silero_vad.threshold">
         <el-input-number v-model="model.silero_vad.threshold" :min="0" :max="1" :step="0.1" :precision="2" style="width: 100%" />
+      </el-form-item>
+      <el-form-item label="退出阈值" prop="silero_vad.threshold_low">
+        <el-input-number v-model="model.silero_vad.threshold_low" :min="0" :max="1" :step="0.1" :precision="2" style="width: 100%" />
       </el-form-item>
       <el-form-item label="最小静音持续时间(ms)" prop="silero_vad.min_silence_duration_ms">
         <el-input-number v-model="model.silero_vad.min_silence_duration_ms" :min="10" :max="5000" style="width: 100%" />
@@ -77,9 +80,13 @@
         <el-input-number v-model="model.ten_vad.hop_size" :min="128" :max="1024" style="width: 100%" />
         <div style="font-size: 12px; color: #909399; margin-top: 4px;">默认：320</div>
       </el-form-item>
-      <el-form-item label="VAD检测阈值" prop="ten_vad.threshold">
+      <el-form-item label="进入阈值" prop="ten_vad.threshold">
         <el-input-number v-model="model.ten_vad.threshold" :min="0" :max="1" :step="0.1" :precision="2" style="width: 100%" />
         <div style="font-size: 12px; color: #909399; margin-top: 4px;">推荐值：0.3</div>
+      </el-form-item>
+      <el-form-item label="退出阈值" prop="ten_vad.threshold_low">
+        <el-input-number v-model="model.ten_vad.threshold_low" :min="0" :max="1" :step="0.1" :precision="2" style="width: 100%" />
+        <div style="font-size: 12px; color: #909399; margin-top: 4px;">推荐值：0.2</div>
       </el-form-item>
       <el-form-item label="连接池大小" prop="ten_vad.pool_size">
         <el-input-number v-model="model.ten_vad.pool_size" :min="1" :max="100" style="width: 100%" />


### PR DESCRIPTION
## Summary
- filter short ASR noise results to reduce false replies like filler tokens
- restart realtime ASR recognition after ASR_OUTPUT hooks stop the current flow
- add VAD hysteresis with threshold / threshold_low for TEN VAD and Silero VAD, including manager config UI

## Tests
- go test ./internal/domain/vad/hysteresis -count=1
- /usr/local/go/bin/go test ./internal/domain/vad/ten_vad ./internal/domain/vad/silero_vad ./internal/app/server/chat -count=1
- CGO_ENABLED=1 /usr/local/go/bin/go build ./cmd/server
- npm run build