### PR TITLE
fix(asr): skip 200ms wait when speaker recognition inactive

### DIFF
--- a/internal/app/server/chat/asr.go
+++ b/internal/app/server/chat/asr.go
@@ -1068,6 +1068,12 @@ func (a *ASRManager) getSpeakerResult() *speaker.IdentifyResult {
 		return nil
 	}
 
+	// 本轮声纹流式识别未激活（整轮无语音/启动失败/上一轮已 finish），
+	// 异步回调不会发送就绪信号，直接返回避免无谓的 200ms 等待。
+	if !a.session.speakerManager.IsActive() {
+		return nil
+	}
+
 	log.Debugf("speakerManager: %+v, IsActive: %+v", a.session.speakerManager, a.session.speakerManager.IsActive())
 
 	timeout := time.NewTimer(200 * time.Millisecond)


### PR DESCRIPTION
getSpeakerResult() only guarded against speakerManager==nil. When voiceprint is enabled but the current turn's streaming identification is not active (no voice detected / StartStreaming failed / previous turn already finished), OnVoiceSilenceSpeakerCallback returns early without signaling speakerResultReady, causing getSpeakerResult() to wait the full 200ms timeout for nothing.

Add an IsActive() check at the entry of getSpeakerResult() to return immediately when the current turn has no active speaker stream.